### PR TITLE
Unit 1 Relative link fixes and missing links

### DIFF
--- a/content/overview/major-projects.md
+++ b/content/overview/major-projects.md
@@ -10,7 +10,7 @@ order: 2
 
 Students work in pairs to complete a design thinking challenge in which they select a user, identify a problem they can solve with an app, program, or device, and then use the design thinking process to create a paper prototype for their design and receive feedback on their design and modify their product based on that feedback. After revisions, each team will present their prototype to the class.
 
-The introduction to the project can be found at [Design Challenge - Discover, Ideate](/unit-1/day-8/design-challenge).
+The introduction to the project can be found at <a href="/unit-1/day-8/design-challenge">Design Challenge - Discover, Ideate</a>.
 
 ### Learning objectives
 
@@ -30,7 +30,7 @@ By working with a partner to create a paper prototype of a program, app, or devi
 
 Students work in small groups to create a static webpage on a Computing Systems and Networks topic. Students present their webpages to the class, teaching each other core concepts related to Computing Systems and Networks.
 
-The introduction to the project can be found at Teaching Tool - Computer Systems and Networks.
+The introduction to the project can be found at <a href="/unit-2/day-9/teaching-tool">Teaching Tool - Computer Systems and Networks</a>.
 
 ### Learning objectives
 
@@ -59,7 +59,7 @@ By working with a partner to create a static webpage on a Computing Systems and 
 
 Students demonstrate their understanding of algorithm implementations by creating a program that includes (1) sequencing, selection, and iteration. Students are tasked with creating a program that seeks user input, uses strings and/or integer variables, and includes visible output. Students can choose whether their program incorporates sprites and projectiles, or calculations.
 
-The introduction to the project can be found at [Unit 3 Culminating Project](#). 
+The introduction to the project can be found at <a href="/unit-3/day-19-22/culminating-project">Unit 3 Culminating Project</a>. 
 
 ### Learning objectives
 
@@ -111,7 +111,7 @@ By creating a program that demonstrates their understanding of algorithm impleme
 
 Students work in groups of three to research and prepare for a debate regarding key topics related to the Impact of Computing unit, including safe computing, legal and ethical concerns, computing bias, and digital divide. Student groups are told on the day of the debate whether they are arguing for or against the topic.
 
-Students are introduced to the project on the [first day of Unit 4 on Slide 4 of the PowerPoint](#). The first day of the project can be found at [Debate Preparation](#), and the topics for the project can be found at [Debate Topics](#).
+Students are introduced to the project on the [first day of Unit 4 on Slide 4 of the PowerPoint](https://1drv.ms/p/s!AqsgsTyHBmRBj1fg-coGpmueZbKS?e=aPQbsO). The first day of the project can be found at <a href="content\unit-4\day-12\debate-preparation">Debate Preparation</a>, and the topics for the project can be found at <a href="/unit-4/day-12/debate-topics">Debate Topics</a>.
 
 ### Learning objectives
 
@@ -135,7 +135,7 @@ By tasking students with debating key topics related to safe computing, legal an
 
 Students demonstrate their understanding of algorithm implementations by creating a program that includes (1) functions and parameters, (2) return values, (3) Boolean statements (selection), (4) logic in loops (iteration), (5) multiplayer interface, (6) scene design using Tile maps, and (7) lists (arrays). Students are tasked with creating a program that seeks user input, includes a visible output, and uses extensions. Students work in small groups to create their program, receiving feedback from others throughout the process. 
 
-The introduction to the project can be found at [Unit 5 Culminating Project](#). 
+The introduction to the project can be found at <a href="/unit-5/day-20-27/culminating-project">Unit 5 Culminating Project</a>. 
 
 ### Learning objectives
 
@@ -190,7 +190,7 @@ By creating a program that demonstrates their understanding of algorithm impleme
 
 Students complete a data research project in Unit 6. Students identify a question they want to research, create a survey to collect data, clean and analyze the data they collect through their survey, and then create a visual representation of the data in an infographic. Students then present their findings to the class.
 
-The introduction to the project can be found at [What is Data Science?](#) and specifically on [Slide 12 on Unit 6 Day 2's PowerPoint](#). Students continue work on the project on Day 3 to learn about [Data Collection](#) and bias in surveys, on Day 4 to learn about [Data Ethics and Survey Creation](#), and on Day 5 for [Testing and Sharing Your Survey](#). Students then wait for their survey results. When they have collected all of their data, they pick back up with the project and apply what they learned about [Data Cleansing and Visualization](#) on Day 6 and then complete their findings by completing an [Infographic Project](#).
+The introduction to the project can be found at <a href="/unit-6/day-2/what-is-data-science">What is Data Science?</a> and specifically on [Slide 12 on Unit 6 Day 2's PowerPoint](https://1drv.ms/p/s!AqsgsTyHBmRBj2mWxLmeJYLj791G?e=YEbkxc). Students continue work on the project on Day 3 to learn about <a href="/unit-6/day-3/data-collection">Data Collection</a> and bias in surveys, on Day 4 to learn about <a href="/unit-6/day-4/data-ethics-survey-creation">Data Ethics and Survey Creation</a>, and on Day 5 for <a href="/unit-6/day-5/testing-sharing-your-survey">Testing and Sharing Your Survey</a>. Students then wait for their survey results. When they have collected all of their data, they pick back up with the project and apply what they learned about <a href="/unit-6/day-6/data-cleansing-visualization">Data Cleansing and Visualization</a> on Day 6 and then complete their findings by completing an <a href="/unit-6/day-7-10/infograpic-project">Infographic Project</a>.
 
 ### Learning objectives
 
@@ -239,7 +239,7 @@ The Mock Exam is a formative assessment that prepares students for the AP Exam s
 
 The WE Unit is an optional unit that can be completed at any time after students complete Unit 5 which likely occurs after students have completed the CPT and AP Exam. Students learn about the WE Pillars of Impact and the United Nation's Sustainable Development Goals (**SDG**). They then investigate one particular Goal in depth and design a programming-based project that addresses a facet of the Goal.
 
-The introduction of the project can be found at [SDG and Programming](#).
+The introduction of the project can be found at <a href="/unit-9/day-1/sustainable-development-goals">SDG and Programming</a>.
 
 ### Learning objectives
 

--- a/content/unit-1/day-10/design-challenge.md
+++ b/content/unit-1/day-10/design-challenge.md
@@ -10,8 +10,8 @@ order: 0
 
 * [Day 10 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkAuzV7Svz0SltNlw?e=fhelUW)
 * [A Pop-Up Japanese Cafe With Robot Servers Remotely Controlled by People With Disabilities](https://youtu.be/7HB6xLe2f3U)
-* [Computing Innovations Activity Worksheet](/unit-1/day-10/computing-innovations-activity)
-* [Computing Innovations Activity Worksheet](#) (in Word)
+* <a href="/unit-1/day-10/computing-innovations-activity">Computing Innovations Activity Worksheet</a>
+* [Computing Innovations Activity Worksheet](https://1drv.ms/w/s!AqsgsTyHBmRBkANWszAEPHMdqLBT?e=JChVcG) (in Word)
 
 ### Instructional Activities and Classroom Assessments
 
@@ -31,34 +31,41 @@ CRD-1.C
 
 ### Essential Knowledge
 
-* [CRD-2.A.1](#) The purpose of computing innovations is to solve problems or to pursue interests through creative expression. 
-* [CRD-2.A.2](#) An understanding of the purpose of a computing innovation provides developers with an improved ability to develop that computing innovation.
-* [CRD-1.C.1](#) Effective collaborative teams practice interpersonal skills, including but not limited to:
+* [CRD-2.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=41) The purpose of computing innovations is to solve problems or to pursue interests through creative expression. 
+* [CRD-2.A.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=41) An understanding of the purpose of a computing innovation provides developers with an improved ability to develop that computing innovation.
+* [CRD-1.C.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=40) Effective collaborative teams practice interpersonal skills, including but not limited to:
     * Communication
     * Consensus building
     * Conflict resolution
     * Negotiation
-* [CRD-2.E.1](#) A development process can be ordered and intentional, or exploratory in nature.
-* [CRD-2.E.2](#) There are multiple development processes. The following phases are commonly used when developing a program: 
+* [CRD-2.E.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=43) A development process can be ordered and intentional, or exploratory in nature.
+* [CRD-2.E.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=43) There are multiple development processes. The following phases are commonly used when developing a program: 
     * Investigating and reflecting
     * Designing
     * Prototyping
     * Testing 
-* [CRD-2.E.3](#) A development process that is iterative requires refinement and revision based on feedback, testing, or reflection throughout the process. This may require revisiting earlier phases of the process.
-* [CRD-2.F.4](#) Program requirements describe how a program functions and may include a description of user interactions that a program must provide.
-* [CRD-2.F.5](#) A program's specification defines the requirements for the program.
-* [CRD-2.F.6](#) In a development process, the design phase outlines how to accomplish a given program specification.
-* [CRD-2.F.7](#) The design phase of a program may include:
+* [CRD-2.E.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=43) A development process that is iterative requires refinement and revision based on feedback, testing, or reflection throughout the process. This may require revisiting earlier phases of the process.
+* [CRD-2.F.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=44) The design of a program incorporates investigation to determine its requirements.
+* [CRD-2.F.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=44) Investigation in a development process is useful for understanding and identifying the program constraints, as well as the concerns and interests of the people who will use the program.
+* [CRD-2.F.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=44) Some ways investigation can be performed are as follows:
+    * Collecting data through surveys
+    * User testing
+    * Interviews
+    * Direct observations
+* [CRD-2.F.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=44)) Program requirements describe how a program functions and may include a description of user interactions that a program must provide.
+* [CRD-2.F.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=44) A program's specification defines the requirements for the program.
+* [CRD-2.F.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=44) In a development process, the design phase outlines how to accomplish a given program specification.
+* [CRD-2.F.7](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=44) The design phase of a program may include:
     * Brainstorming
     * Planning and storyboarding
     * Organizing the program into modules and functional components
     * Creation of diagrams that represent the layouts of the user interface
     * Development of a testing strategy for the program
-* [IOC-1.A.1](#) People create computing innovations.
-* [IOC-1.A.2](#) The way people complete tasks often changes to incorporate new computing innovations.
-* [IOC-1.A.3](#) Not every effect of a computing innovation is anticipated in advance.
-* [IOC-1.A.4](#) A single effect can be viewed as both beneficial and harmful by different people, or even by the same person.
-* [IOC-1.A.5](#) Advances in computing have generated and increased creativity in other fields, such as medicine, engineering, communications, and the arts.
+* [IOC-1.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) People create computing innovations.
+* [IOC-1.A.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) The way people complete tasks often changes to incorporate new computing innovations.
+* [IOC-1.A.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) Not every effect of a computing innovation is anticipated in advance.
+* [IOC-1.A.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) A single effect can be viewed as both beneficial and harmful by different people, or even by the same person.
+* [IOC-1.A.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) Advances in computing have generated and increased creativity in other fields, such as medicine, engineering, communications, and the arts.
 
 ## Details
 

--- a/content/unit-1/day-11/computing-innovations.md
+++ b/content/unit-1/day-11/computing-innovations.md
@@ -10,7 +10,7 @@ order: 0
 
 * [Day 11 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkA4vRFCEM20mHtlF?e=y9rJsg)
 * [Seeing AI app from Microsoft](https://youtu.be/bqeQByqf_f8)
-* [Impact of a Computing Innovation - Recurring Assignment Handout](/unit-1/day-11/impact-computing-innovation)
+* <a href="/unit-1/day-11/impact-computing-innovation">Impact of a Computing Innovation - Recurring Assignment Handout</a>
 * [Impact of a Computing Innovation - Recurring Assignment Handout](https://1drv.ms/w/s!AqsgsTyHBmRBkANWszAEPHMdqLBT?e=bPgDlu) (in Word)
 
 ### Instructional Activities and Classroom Assessments

--- a/content/unit-1/day-12/computing-innovation.md
+++ b/content/unit-1/day-12/computing-innovation.md
@@ -12,7 +12,7 @@ order: 0
 * [DigiPen Student Video Games](https://youtu.be/Gpvr130vxrQ)
 * [MakeCode Arcade](https://arcade.makecode.com)
 * Optional: [MakeCode Arcade Hardware](https://arcade.makecode.com/hardware)
-* Optional: [Arcade Sprite Stencils](/unit-1/day-12/arcade-sprite-stencils)
+* Optional: <a href="/unit-1/day-12/arcade-sprite-stencils">Arcade Sprite Stencils</a>
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-1/day-15/impact-computing-assignment.md
+++ b/content/unit-1/day-15/impact-computing-assignment.md
@@ -10,7 +10,7 @@ You will select the day that you do this activity with your students. Communicat
 
 ### Materials
 
-* [Impact of a Computing Innovation - Recurring Assignment](/unit-1/day-11/impact-computing-innovation) (already handed out to students on Day 11 of Unit 1)
+* <a href="/unit-1/day-11/impact-computing-innovation">Impact of a Computing Innovation - Recurring Assignment</a> (already handed out to students on Day 11 of Unit 1)
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-1/day-5/teamwork-principles.md
+++ b/content/unit-1/day-5/teamwork-principles.md
@@ -44,7 +44,7 @@ order: 0
 
 ### 2. Teamwork Activity (20 minutes) 
 
-* Use the [Spaghetti Tower Challenge](/unit-1/day-5/spagetti-tower-challenge) directions to set up the activity.
+* Use the <a href="/unit-1/day-5/spagetti-tower-challenge">Spaghetti Tower Challenge</a> directions to set up the activity.
 * Divide the class up into groups of 3-5 students.
 * You can use the Group Generator program to randomly sort students.
 * Instruct students that they have 18 minutes to build the tallest tower possible that will support a marshmallow with the supplies provided.

--- a/content/unit-1/day-6/design-thinking.md
+++ b/content/unit-1/day-6/design-thinking.md
@@ -11,10 +11,10 @@ order: 0
 * [Day 6 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkAondcAaLVHZG9va?e=oqU7Vs)
 * [Microsoft Design: Empathy](https://youtu.be/ESTTX2u7Xi4) (with audio description)
 * Blank paper for Crazy 8 activity
-* [Design Thinking Practice: Create the Perfect House](/unit-1/day-6/design-thinking-practice)
+* <a href="/unit-1/day-6/design-thinking-practice">Design Thinking Practice: Create the Perfect House</a>
 * [Design Thinking Practice: Create the Perfect House](https://1drv.ms/w/s!AqsgsTyHBmRBj303Jh9kwmVIG2Cr?e=Ns9ITW) (worksheet in Word)
-* Optional: [Micro:bit Micro Pet Activity](/unit-1/day-6/micro-pet-activity)
-* Optional: [Minecraft Build a House](/unit-1/day-6/minecraft-build-house)
+* Optional: <a href="/unit-1/day-6/micro-pet-activity">Micro:bit Micro Pet Activity</a>
+* Optional: <a href="/unit-1/day-6/minecraft-build-house">Minecraft Build a House</a>
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-1/day-8/design-challenge.md
+++ b/content/unit-1/day-8/design-challenge.md
@@ -9,11 +9,11 @@ order: 0
 ### Materials
 
 * [Day 8 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkA2VcVjlPzaNH-K7?e=BXYWm5)
-* [Design Challenge Guide Handout](/unit-1/day-8/design-challenge-guide)
+* <a href="/unit-1/day-8/design-challenge-guide">Design Challenge Guide Handout</a>
 * [Design Challenge Guide Handout](https://1drv.ms/w/s!AqsgsTyHBmRBkAH7AzPkfnzAuQ9c?e=vzT5IB) (in Word)
-* [Rules for Brainstorming Handout](/unit-1/day-8/rules-for-brainstorming)
+* <a href="/unit-1/day-8/rules-for-brainstorming">Rules for Brainstorming Handout</a>
 * [Rules for Brainstorming Handout](https://1drv.ms/w/s!AqsgsTyHBmRBj3_s1ybPvmJHZbCJ?e=19VP6u) (in PDF)
-* [Prototyping Prep Homework Handout](/unit-1/day-8/prototyping-prep-homework)
+* <a href="/unit-1/day-8/prototyping-prep-homework">Prototyping Prep Homework Handout</a>
 * [Prototyping Prep Homework Handout](https://1drv.ms/w/s!AqsgsTyHBmRBkAAoQ1MTEbWdNLgc?e=19VP6u) (in Word)
 
 ### Instructional Activities and Classroom Assessments

--- a/content/unit-1/day-9/design-challenge.md
+++ b/content/unit-1/day-9/design-challenge.md
@@ -9,8 +9,8 @@ order: 0
 ### Materials
 
 * [Day 9 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkAy_Is3FQcSwyG-o?e=WhuXwB)
-* [Design Challenge Guide Handout](/unit-1/day-8/design-challenge-guide) (shared with students on Day 8)
-* [Design Challenge Reflection](/unit-1/day-9/design-challenge-reflection) Handout 
+* <a href="/unit-1/day-8/design-challenge-guide">Design Challenge Guide Handout</a> (shared with students on Day 8)
+* <a href="/unit-1/day-9/design-challenge-reflection">Design Challenge Reflection</a> Handout 
 * [Design Challenge Reflection](https://1drv.ms/w/s!AqsgsTyHBmRBkALbIY1YXA73XnLm?e=gcYKrF) Handout (in Word)
 
 ### Instructional Activities and Classroom Assessments

--- a/content/unit-1/introduction.md
+++ b/content/unit-1/introduction.md
@@ -28,7 +28,7 @@ The questions students will explore in this unit include:
 
 ## Computational Thinking Practices: 
 
-Computational Solution Design    
+[Computational Solution Design](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=23)
 
 * 1.A Investigate the situation, context, or task. 
 * 1.B Determine and design an appropriate method or approach to achieve the purpose. 
@@ -37,15 +37,15 @@ Computational Solution Design
 
 ## Big Ideas
 
-[Big Idea 1: Creative Development (CRD)](#)
+[Big Idea 1: Creative Development (CRD)](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=24)
 
 >When developing computing innovations, developers can use a formal, iterative design process or a less rigid process of experimentation. While using either approach, developers will encounter phases of investigating and reflecting, designing, prototyping, and testing. Additionally, collaboration is an important tool at any phase of development, because considering multiple perspectives allows for improvement of innovations.
 
 ## Enduring Understandings
 
-[CRD-1](#) Incorporating multiple perspectives through collaboration improves computing innovations as they are developed.
+[CRD-1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=39) Incorporating multiple perspectives through collaboration improves computing innovations as they are developed.
 
-[CRD-2](#) Developers create and innovate using an iterative design process that is user-focused, that incorporates implementation/feedback cycles, and that leaves ample room for experimentation and risk-taking.
+[CRD-2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=41) Developers create and innovate using an iterative design process that is user-focused, that incorporates implementation/feedback cycles, and that leaves ample room for experimentation and risk-taking.
 
 ## Projects and Major Assessments
 
@@ -57,25 +57,24 @@ Computational Solution Design
 * Unit 1 Educator PowerPoint decks.
 * Unit 1 Videos.
 * Unit 1 Student Activities and Homework Assignments.
-* Spaghetti Tower Challenge.
+* <a href="/unit-1/day-5/spagetti-tower-challenge">Spaghetti Tower Challenge</a>
 * Internet access to these sites:
-    * MakeCode Arcade
-    * AP Classroom
-    * List of famous computer scientists
-    * Dell Laptop Computers
-    * Microsoft Design: Empathy (with audio description)
-    * Microsoft Inclusive Design 
-    * IDEO U
-    * What is Design Thinking? 
-    * A Pop-Up Japanese Cafe With Robot Servers Remotely Controlled by People With Disabilities
-    * Seeing AI app from Microsoft
-    * DigiPen Student Video Games
+    * [MakeCode Arcade](https://arcade.makecode.com)
+    * [AP Classroom](https://myap.collegeboard.org/login)
+    * <a href="https://www.ranker.com/list/notable-computer-scientist_s)/reference">List of famous computer scientists</a>
+    * [Dell Laptop Computers](https://www.dell.com/en-us/shop/scc/sc/laptops)
+    * [Microsoft Design: Empathy](https://youtu.be/ESTTX2u7Xi4) (with audio description)
+    * [Microsoft Inclusive Design](https://www.microsoft.com/design/inclusive/)
+    * [IDEO U|What is Design Thinking?](https://youtu.be/ldYzbV0NDp8)
+    * [A Pop-Up Japanese Cafe With Robot Servers Remotely Controlled by People With Disabilities](https://youtu.be/7HB6xLe2f3U)
+    * [Seeing AI app from Microsoft](https://youtu.be/bqeQByqf_f8)
+    * [DigiPen Student Video Games](https://youtu.be/Gpvr130vxrQ)
 
 ### Optional
 
-* MakeCode Arcade Hardware 
+* [MakeCode Arcade Hardware](https://arcade.makecode.com/hardware)
 * Micro:bits 
-* Micro:bit Micro Pet Activity 
-* micro:bit Features Overview 
+* <a href="/unit-1/day-6/micro-pet-activity">Micro:bit Micro Pet Activity</a>
+* [micro:bit Features Overview](https://microbit.org/get-started/user-guide/overview/)
 * Minecraft Education Edition 
-* Minecraft Build a House 
+* <a href="/unit-1/day-6/minecraft-build-house">Minecraft Build a House</a>


### PR DESCRIPTION
Relative links from markdown will get a duplicated path prefix `makecode-csp` prepended. This quirk is handled by using raw anchors instead `<a href="">...</a>`. Using ``<Link>`` will work also but the styles for `<a>` aren't inherited.

- [x] Change relative links from markdown format to `<a>`.
- [x] Check for other missing links too and fill them in.