### PR TITLE
Unit 2 and 3 Relative link fixes

### DIFF
--- a/content/unit-2/day-1/how-does-internet-work.md
+++ b/content/unit-2/day-1/how-does-internet-work.md
@@ -10,11 +10,11 @@ order: 0
 
 * [Day 1 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBjzZs__tNSQiZSH5L?e=I4KlHk)
 * [Vox Video - How Does the Internet Work? - Glad You Asked S1](https://youtu.be/TNQsmPf24go)
-* [Guided Video Notes: How Does the Internet Work?](/unit-2/day-1/guided-video-notes)
-* [Answer Key to Guided Video Notes](/unit-2/day-1/answer-key-guided-video-notes)
-* [The Internet as System and Spirit Reading Assignment](/unit-2/day-1/internet-system-spirit)
-* [Guided Reading Questions: The Internet as a System and Spirit](/unit-2/day-1/guided-reading-questions)
-* [Answer Key to Guided Reading Questions](/unit-2/day-1/answer-key-guided-reading-notes)
+* <a href="/unit-2/day-1/guided-video-notes">Guided Video Notes: How Does the Internet Work?</a>
+* <a href="/unit-2/day-1/answer-key-guided-video-notes">Answer Key to Guided Video Notes</a>
+* <a href="/unit-2/day-1/internet-system-spirit">The Internet as System and Spirit Reading Assignment</a>
+* <a href="/unit-2/day-1/guided-reading-questions">Guided Reading Questions: The Internet as a System and Spirit</a>
+* <a href="/unit-2/day-1/answer-key-guided-reading-notes">Answer Key to Guided Reading Questions</a>
 
 ### Instructional Activities and Classroom Assessments
 
@@ -68,13 +68,13 @@ ap-computer-science-principles-course-and-exam-description.pdf#page=23)
 
 * Watch the video.
 * As students watch the video, ask them to answer the questions on the Guided Video Notes page.
-* You may need to pause the video periodically to allow students a moment to write down their answers to the questions on the [Guided Video Notes: How Does the Internet Work?](#) page.
+* You may need to pause the video periodically to allow students a moment to write down their answers to the questions on the <a href="/unit-2/day-1/guided-video-notes">Guided Video Notes: How Does the Internet Work?</a> page.
 
 ### 3. How Does the Internet Work? Discussion (10 minutes)
 
 * Discuss what students learned by watching the video.
 * Ask students to share their answers on the Guided Video Notes page.
-* Use the [Answer Key to Guided Video Notes](#) to help with the discussion.
+* Use the <a href="/unit-2/day-1/answer-key-guided-video-notes">Answer Key to Guided Video Notes</a> to help with the discussion.
 
 ### 4. Homework
 

--- a/content/unit-2/day-11/teaching-tool-work-day.md
+++ b/content/unit-2/day-11/teaching-tool-work-day.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 11 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj0TRbNliGoWJOKK8?e=jhTvcJ)
-* [Webpage Link for Viewing](/unit-2/day-11/webpage-link) (directions and place for students to share their links)
+* <a href="/unit-2/day-11/webpage-link">Webpage Link for Viewing</a> (directions and place for students to share their links)
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-2/day-12/teaching-tool-presentations.md
+++ b/content/unit-2/day-12/teaching-tool-presentations.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 12 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj0UCf2ESIb4tkJIW?e=FvhhKG)
-* [Webpage Link for Viewing](/unit-2/day-12/project-reflection) (directions and place for students to share their links)
+* <a href="/unit-2/day-12/project-reflection">Webpage Link for Viewing</a> (directions and place for students to share their links)
 
 ### Instructional Activities and Classroom Assessments
 
@@ -67,4 +67,4 @@ After presenting, the audience can give constructive feedback.
 
 ### 4. Homework
 
-* Students will complete the [Project Reflection](/unit-2/day-12/project-reflection) page for homework.
+* Students will complete the <a href="/unit-2/day-12/project-reflection">Project Reflection</a> page for homework.

--- a/content/unit-2/day-13/impact-of-computing-assignment.md
+++ b/content/unit-2/day-13/impact-of-computing-assignment.md
@@ -8,7 +8,7 @@ order: 0
 
 ### Materials
 
-[Impact of a Computing Innovation - Recurring Assignment](/unit-1/day-11/impact-computing-innovation) (already handed out to students on Day 11 of Unit 1)
+<a href="/unit-1/day-11/impact-computing-innovation">Impact of a Computing Innovation - Recurring Assignment</a> (already handed out to students on Day 11 of Unit 1)
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-2/day-2/computing-devices-iot.md
+++ b/content/unit-2/day-2/computing-devices-iot.md
@@ -9,11 +9,11 @@ order: 0
 ### Materials
 
 * [Day 2 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBjzd_CMDtjVDv-fbi?e=KkvFaX)
-* Group Activity: [IoT Examples](/unit-2/day-1/iot-examples)
+* Group Activity: <a href="/unit-2/day-1/iot-examples">IoT Examples</a>
 * Handouts (also used on Day 1):
-    * [The Internet as System and Spirit](/unit-2/day-1/internet-system-spirit)
-    * [Guided Reading Questions: The Internet as a System and Spirit](/unit-2/day-1/guided-reading-questions)
-    * [Answer Key to Guided Reading Questions](/unit-2/day-1/answer-key-guided-reading-notes)
+    * <a href="/unit-2/day-1/internet-system-spirit">The Internet as System and Spirit</a>
+    * <a href="/unit-2/day-1/guided-reading-questions">Guided Reading Questions: The Internet as a System and Spirit</a>
+    * <a href="/unit-2/day-1/answer-key-guided-reading-notes">Answer Key to Guided Reading Questions</a>
 
 ### Instructional Activities and Classroom Assessments 
 

--- a/content/unit-2/day-4/homework.md
+++ b/content/unit-2/day-4/homework.md
@@ -6,7 +6,7 @@ order: 2
 
 ## Resources for your homework:
 
-[Notetaking template](/unit-2/day-4/notetaking-template)
+<a href="/unit-2/day-4/notetaking-template">Notetaking template</a>
 
 ## Complete the following tasks before class tomorrow:
 

--- a/content/unit-2/day-4/how-does-internet-work.md
+++ b/content/unit-2/day-4/how-does-internet-work.md
@@ -9,9 +9,9 @@ order: 0
 ### Materials
 
 * [Day 4 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBjzr4T5k74i_qHG9i?e=rvHyZH)
-* [Preparation for Packet Switching Game](/unit-2/day-4/prep-packet-switching-game)
-* [Day 4 Homework](/unit-2/day-4//homework)
-* [Notetaking template](/unit-2/day-4/notetaking-template)
+* <a href="/unit-2/day-4/prep-packet-switching-game">Preparation for Packet Switching Game</a>
+* <a href="/unit-2/day-4/homework">Day 4 Homework</a>
+* <a href="/unit-2/day-4/notetaking-template">Notetaking template</a>
 
 ### Instructional Activities and Classroom Assessments 
 

--- a/content/unit-2/day-6/parallel-distributed-computing.md
+++ b/content/unit-2/day-6/parallel-distributed-computing.md
@@ -11,8 +11,8 @@ order: 0
 * [Day 6 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBjz2n4qHObblYfWJu?e=7JO3H6)
 * Deck of cards for each small group
 * [Big Data In 5 Minutes | What Is Big Data?| Introduction To Big Data |Big Data Explained |Simplilearn](https://youtu.be/bAyrObl7TYE)
-* [Real World Scenarios Handout](/unit-2/day-6/real-world-scenarios) (cut the paper to separate each scenario)
-* [Day 6 Reflection](/unit-2/day-6/reflection) (Homework)
+* <a href="/unit-2/day-6/real-world-scenarios">Real World Scenarios Handout</a> (cut the paper to separate each scenario)
+* <a href="/unit-2/day-6/reflection">Day 6 Reflection</a> (Homework)
 * [Day 6 Reflection](https://1drv.ms/w/s!AqsgsTyHBmRBjzuTk5OBzbu1BTi7?e=ewM0jk) (Homework) in Word
 
 ### Instructional Activities and Classroom Assessments

--- a/content/unit-2/day-7/world-wide-web.md
+++ b/content/unit-2/day-7/world-wide-web.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 7 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBjz4Vb2YFXvDC8cH6?e=daV11t)
-* [Unit 2 Vocab](/unit-2/vocab)
+* <a href="/unit-2/vocab">Unit 2 Vocab</a>
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-2/day-9/teaching-tool.md
+++ b/content/unit-2/day-9/teaching-tool.md
@@ -9,9 +9,9 @@ order: 0
 ### Materials
 
 * [Day 9 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj0LNGoCTK9Gh_r9w?e=F1UVZv)
-* [Webpage Design Document](/unit-2/day-9/webpage-design-document)
+* <a href="/unit-2/day-9/webpage-design-document">Webpage Design Document</a>
 * [Webpage Design Document](https://1drv.ms/w/s!AqsgsTyHBmRBj0GcwFakEJmF7BZz?e=kryCan) (in Word)
-* [Web Page Project Rubric](/unit-2/day-9/webpage-project-rubric)
+* <a href="/unit-2/day-9/webpage-project-rubric">Web Page Project Rubric</a>
 * [Web Page Project Rubric](https://1drv.ms/w/s!AqsgsTyHBmRBj0B65c7OyROKdLh7?e=wbT4wY) (in Word)
 
 ### Instructional Activities and Classroom Assessments

--- a/content/unit-3/day-1/intro-algorithms-programming.md
+++ b/content/unit-3/day-1/intro-algorithms-programming.md
@@ -9,9 +9,9 @@ order: 0
 ### Materials
 
 * [Day 1 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkEvvJU0wJ35hu67B?e=D11ge7)
-* [Flowchart Activity](/unit-3/day-1/flowchart-activity)
+* <a href="/unit-3/day-1/flowchart-activity">Flowchart Activity</a>
 * [Flowchart Activity](https://1drv.ms/w/s!AqsgsTyHBmRBkDtw-KHmmcv4s_ju?e=t14mFR) in Word
-* [Reflection](/unit-3/day-1/reflection)
+* <a href="/unit-3/day-1/reflection">Reflection</a>
 * [Reflection](https://1drv.ms/w/s!AqsgsTyHBmRBkD2lJ5ICRgPwXqSj?e=h6zsIU) (in Word)
 * [What's an algorithm? - David J. Malan](https://youtu.be/6hfOvs8pY1k)
 * [Why algorithms are called algorithms | BBC Ideas](https://youtu.be/oRkNaF0QvnI)
@@ -83,7 +83,7 @@ order: 0
 
 ### 5. Homework- Where else are algorithms?
 
-* Students can complete their [Reflection](/unit-3/day-1/reflection) in their OneNote or other journal location.
+* Students can complete their <a href="/unit-3/day-1/reflection">Reflection</a> in their OneNote or other journal location.
 * How do algorithms affect our daily lives? Our society?
 * Where else are algorithms?
     * Research an area where algorithms are used (travel/transportation, shipping, retail, gaming, medicine, science, climate, society, etc.).   

--- a/content/unit-3/day-10/string-variables.md
+++ b/content/unit-3/day-10/string-variables.md
@@ -12,7 +12,7 @@ order: 0
 * [MakeCode Arcade](https://arcade.makecode.com)
 * [Name String](https://arcade.makecode.com/56228-63714-53573-16612) (for teacher)
 * [Parts of Speech](https://arcade.makecode.com/20670-08492-67506-63325)  (for teacher)
-* [My Code Segments for String Activities](/unit-3/day-10/my-code-segments)
+* <a href="/unit-3/day-10/my-code-segments">My Code Segments for String Activities</a>
 
 ## Instructional Activities and Classroom Assessments
 

--- a/content/unit-3/day-11/boolean-variables.md
+++ b/content/unit-3/day-11/boolean-variables.md
@@ -14,8 +14,8 @@ order: 0
 * [Boolean Operators](https://arcade.makecode.com/57551-12513-04910-43977) Code (for teacher)
 * [Drive or Bike](https://arcade.makecode.com/13918-34640-72259-96223) Code (for teacher)
 * [Drive or Bike Mod](https://arcade.makecode.com/43415-56110-88445-09956) Code (for teacher)
-* [Boolean Operator Practice](/unit-3/day-11/boolean-operator-practice) page
-* [My Code Segments for Boolean Activities](/unit-3/day-11/my-code-segments) page
+* <a href="/unit-3/day-11/boolean-operator-practice">Boolean Operator Practice</a> page
+* <a href="/unit-3/day-11/my-code-segments">My Code Segments for Boolean Activities</a> page
 
 ### Instructional Activities and Classroom Assessments 
 

--- a/content/unit-3/day-12/conditional-statements.md
+++ b/content/unit-3/day-12/conditional-statements.md
@@ -12,7 +12,7 @@ order: 0
 * [MakeCode Arcade](https://arcade.makecode.com)
 * [Drive or Bike User Input](https://arcade.makecode.com/34668-94710-92911-69140) (for teacher)
 * [Discount Program](https://arcade.makecode.com/51605-77853-77108-54314) (for teacher)
-* [Putting it all Together Project](/unit-3/day-12/putting-together)
+* <a href="/unit-3/day-12/putting-together">Putting it all Together Project</a>
 * Note to teacher: You can find directions for how to create a screencast [here](https://1drv.ms/w/s!AqsgsTyHBmRBkCZowEPHadJxKSRc?e=8ioyKG). There is a PowerPoint for a variety of devices (Windows 10, Mac, iPad, and Chromebook).
 
 ### Instructional Activities and Classroom Assessments

--- a/content/unit-3/day-13/random-part-1.md
+++ b/content/unit-3/day-13/random-part-1.md
@@ -10,12 +10,12 @@ order: 0
 
 * [Day 13 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFiQfWReiXGXcgZm?e=rFMVVm)
 * Dice (or a [virtual die](https://www.random.org/dice/))
-* [Roll the Dice Handout](/unit-3/day-13/roll-the-dice) 
+* <a href="/unit-3/day-13/roll-the-dice">Roll the Dice Handout</a>
 * [Roll the Dice Handout](https://1drv.ms/w/s!AqsgsTyHBmRBkGAZBqJvKCnOOen4?e=CYs1Qu) in Word 
-* [Class Results for Roll the Dice](unit-3/day-13/class-results-roll-dice)
-* [How Computers Generate Random Numbers article](/unit-3/day-13/generate-random-numbers)
+* <a href="unit-3/day-13/class-results-roll-dice">Class Results for Roll the Dice</a>
+* <a href="/unit-3/day-13/generate-random-numbers">How Computers Generate Random Numbers article</a>
 * [Is Anything Truly Random?](https://youtu.be/tClZGWlRLoE) video
-* [Tutorials on Randomness](/unit-3/day-13/tutorials-on-randomness) handout
+* <a href="/unit-3/day-13/tutorials-on-randomness">Tutorials on Randomness</a> handout
 * [Tutorials on Randomness](https://1drv.ms/w/s!AqsgsTyHBmRBkEJj0_aW30xXHlgl?e=uJ5VXs) in Word
 * [Activity: Random Sprite Location](https://arcade.makecode.com/courses/csintro1/motion/random)
 

--- a/content/unit-3/day-14/random-part-2.md
+++ b/content/unit-3/day-14/random-part-2.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 14 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFZnQpW7T3ivfkKP?e=joQeF2)
-* [Random Generator Programs](/unit-3/day-14/random-generator-programs) handout
+* <a href="/unit-3/day-14/random-generator-programs">Random Generator Programs</a> handout
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-3/day-15/loops.md
+++ b/content/unit-3/day-15/loops.md
@@ -10,8 +10,8 @@ order: 0
 
 * [Day 15 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFtFKBNBX8EycxaK?e=zNWZHE)
 * [Calculate Ages in Room](https://arcade.makecode.com/76893-69118-16057-22226) (for teacher)
-* [Repetition in Every Day Life](/unit-3/day-15/repetition-everyday-life)
-* [My Animation Code Segments](/unit-3/day-15/my-code-segments)
+* <a href="/unit-3/day-15/repetition-everyday-life">Repetition in Every Day Life</a>
+* <a href="/unit-3/day-15/my-code-segments">My Animation Code Segments</a>
 * [animationLoop](https://arcade.makecode.com/43154-73409-72381-32539) (for teacher)
 * [animationNestedLoop](https://arcade.makecode.com/71765-80266-12212-81327) (for teacher)
 * [ghost loop animation](https://arcade.makecode.com/64919-27411-47643-88406) (for teacher)

--- a/content/unit-3/day-16/projectiles-part-1.md
+++ b/content/unit-3/day-16/projectiles-part-1.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 16 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFlACJPIhnJmrzTw?e=njGJ7k)
-* [Projectiles Activities](/unit-3/day-16/projectiles-activities)
+* <a href="/unit-3/day-16/projectiles-activities">Projectiles Activities</a>
 * [Projectiles Activities](https://1drv.ms/w/s!AqsgsTyHBmRBkEfrma_O-9Zo3CH1?e=hPsQKA) in Word
 * [Flying Bird Program](https://arcade.makecode.com/86954-34244-21437-84571) (for teacher)
 * [Flying Bird with Score Program](https://arcade.makecode.com/30232-17754-55240-22877) (for teacher)
@@ -76,7 +76,7 @@ block of statements condition in which the code in block of statements is repeat
 * Review sprites.
 * Remind students of our use of Projectiles in the Galga game.
 * Define and discuss the qualities of projectiles.
-* Direct students to the [Projectiles Activities](/unit-3/day-16/projectiles-activities) page and guide them through Section A of the page (i.e., the Flying Bird activity).
+* Direct students to the <a href="/unit-3/day-16/projectiles-activities">Projectiles Activities</a> page and guide them through Section A of the page (i.e., the Flying Bird activity).
 * Discuss what happens when they change the numbers for vx and vy.
 * Discuss what happens when they change vx or vy to a negative number.
 * Demonstrate the concept that projectiles are automatically destroyed when they leave the visible screen:
@@ -85,7 +85,7 @@ block of statements condition in which the code in block of statements is repeat
 
 ### 3. Projectiles activities (35 minutes)
 
-* Direct students to the [Projectiles Activities](/unit-3/day-16/projectiles-activities) page.
+* Direct students to the <a href="/unit-3/day-16/projectiles-activities">Projectiles Activities</a> page.
 * Task them with completing Section B of the page.
 
 ### 4. Reflection/Homework

--- a/content/unit-3/day-17/projectiles-part-2.md
+++ b/content/unit-3/day-17/projectiles-part-2.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials  
 
 * [Day 17 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFqE6eb8hFfDBtLb?e=Ubcegp)
-* [Projectiles from Sprites Activities](/unit-3/day-17/projectiles-sprites-activities)
+* <a href="/unit-3/day-17/projectiles-sprites-activities">Projectiles from Sprites Activities</a>
 * [Projectiles from Sprite Activities](https://1drv.ms/w/s!AqsgsTyHBmRBkEOV8pwD1BQqvKFW?e=vOahsb) in Word
 * [Projectiles from Sprites Tutorials](https://arcade.makecode.com/courses/csintro1/loops/projectile-from) 
 

--- a/content/unit-3/day-18/text-based-programming.md
+++ b/content/unit-3/day-18/text-based-programming.md
@@ -9,12 +9,12 @@ order: 0
 ### Materials  
 
 * [Day 18 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkF23KafW4i1RjV2n?e=aoD0Cy)
-* [Levels of Programming Languages](content/unit-3/day-18/levels-of-languages) handout
+* <a href="/unit-3/day-18/levels-of-languages">Levels of Programming Languages</a> handout
 * [Levels of Programming Languages](https://1drv.ms/w/s!AqsgsTyHBmRBkEZ2vTTaeMjjZ-A_?e=sfgbay) handout in Word
-* [JavaScript Commands](/unit-3/day-18/javascript-commands)
+* <a href="/unit-3/day-18/javascript-commands">JavaScript Commands</a>
 * [JavaScript Commands](https://1drv.ms/w/s!AqsgsTyHBmRBkEVcn6F1OuOIMnWm?e=hRGFsi) in Word
 * [Lemon Leak JavaScript](https://arcade.makecode.com/98004-90663-66831-30590) (for teacher)
-* [Code Tracing & Rewrite in JavaScript](/unit-3/day-18/rewrite-in-javascript) handout
+* <a href="/unit-3/day-18/rewrite-in-javascript">Code Tracing & Rewrite in JavaScript</a> handout
 * [Code Tracing & Rewrite in JavaScript](https://1drv.ms/w/s!AqsgsTyHBmRBkET45PKWFfcpLVja?e=7VhAc3) handout in Word
 * Block code-segments used in assignment:
     * [driver nested conditional](https://arcade.makecode.com/70022-63731-41202-63500) (for teacher)

--- a/content/unit-3/day-19-22/culminating-project.md
+++ b/content/unit-3/day-19-22/culminating-project.md
@@ -9,11 +9,11 @@ order: 0
 ### Materials
 
 * [Days 19-22 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFyXQ-ooj03xM0wA/e=jYCzol)
-* [Project Requirements & Responses](/unit-3/day-19-22/projects-requirements-responses) handout
+* <a href="/unit-3/day-19-22/projects-requirements-responses">Project Requirements & Responses</a> handout
 * [Project Requirements & Responses](https://1drv.ms/w/s!AqsgsTyHBmRBkEqcSqfKEXwpxWhd?e=Yf1WQk) handout in Word
-* [Project Rubric](/unit-3/day-19-22/project-rubric) handout
+* <a href="(/unit-3/day-19-22/project-rubric">Project Rubric</a> handout
 * [Project Rubric](https://1drv.ms/w/s!AqsgsTyHBmRBkEIRSupu4ZlwIkh7?e=yCFckj) in Word
-* [Planning Your Program](/unit-3/day-19-22/planning-your-program) handout
+* <a href="/unit-3/day-19-22/planning-your-program">Planning Your Program</a> handout
 * [Planning Your Program](https://1drv.ms/w/s!AqsgsTyHBmRBkEgG4aDnyEMeNLfd?e=91cOiE) handout in Word
 
 ### Instructional Activities and Classroom Assessments

--- a/content/unit-3/day-2/coding-algorithms.md
+++ b/content/unit-3/day-2/coding-algorithms.md
@@ -11,7 +11,7 @@ order: 0
 * [Day 2 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkEyuzg5H3d9wFCXh?e=Lm9uJi)
 * [Binary & Essay Algorithm Steps](https://1drv.ms/w/s!AqsgsTyHBmRBkD9fpVWbRXbPJoy1?e=jK9wFn) (for teacher's reference) 
 * [Binary & Essay Algorithm Steps for Cutting Out](https://1drv.ms/w/s!AqsgsTyHBmRBkDxG908Asal8GlMv?e=3s38hf) (for Student Activity) 
-* [Mathematical Algorithms](/unit-3/day-2/mathematical-algorithms)
+* <a href="/unit-3/day-2/mathematical-algorithms">Mathematical Algorithms</a>
 * [MakeCode Arcade](https://arcade.makecode.com/)
 * [min and max code](https://arcade.makecode.com/42921-82073-24965-68366)
 * [min and max bonus code](https://arcade.makecode.com/56199-68110-39592-84517)

--- a/content/unit-3/day-3/refining-debugging-algorithms.md
+++ b/content/unit-3/day-3/refining-debugging-algorithms.md
@@ -11,7 +11,7 @@ order: 0
 * [Day 3 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkE3VD8KutavMfQ6j?e=QPHDZt)
 * [MakeCode Arcade](https://arcade.makecode.com/)
 * [Calculate Ages in Room code](https://arcade.makecode.com/76893-69118-16057-22226) (for teacher)
-* [My Add Ages in the Room Program](/unit-3/day-3/my-add-ages)
+* <a href="/unit-3/day-3/my-add-ages">My Add Ages in the Room Program</a>
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-3/day-4/events.md
+++ b/content/unit-3/day-4/events.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials 
 
 * [Day 4 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFH3kou9YRVO_kPf?e=UFvSVT)
-* [My Galga Game](/unit-3/day-4/my-galga-game)
+* <a href="/unit-3/day-4/my-galga-game">My Galga Game</a>
 * [MakeCode Arcade](https://arcade.makecode.com/)
 * [Which Button?](https://arcade.makecode.com/79378-08701-86920-14976) code (for teacher)
 * [Galga code](https://arcade.makecode.com/35288-47032-68910-16297) (for teacher)
@@ -59,7 +59,7 @@ AAP-2.B.6 Sequential statements execute in the order they appear in the code seg
     * On game update
     * On A button pressed
     * On sprite overlaps
-* Ask students to publish their game and post the link to their [My Galga Game](/unit-3/day-4/my-galga-game) page.
+* Ask students to publish their game and post the link to their <a href="/unit-3/day-4/my-galga-game">My Galga Game</a> page.
 * Encourage students to save their game to their computer also.
 * Have students play their game a few times to see how it works.
 
@@ -69,4 +69,4 @@ AAP-2.B.6 Sequential statements execute in the order they appear in the code seg
 * Students should explore other game features and insert items they feel will work with their vision for the game.
 * Show them how to learn what different blocks do by using the Help feature.
 * Encourage students to add comments to the blocks they add.
-* Ask students to re-publish their game and add the link to their [My Galga Game](/unit-3/day-4/my-galga-game).
+* Ask students to re-publish their game and add the link to their <a href="/unit-3/day-4/my-galga-game">My Galga Game</a>.

--- a/content/unit-3/day-6/sprite-stories.md
+++ b/content/unit-3/day-6/sprite-stories.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 6 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkE7swOx0rn8PeZtJ?e=HPleQK)
-* [Sprite Stories Submissions](/unit-3/day-6/sprite-stories-submissions)
+* <a href="/unit-3/day-6/sprite-stories-submissions">Sprite Stories Submissions</a>
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-3/day-7/robots.md
+++ b/content/unit-3/day-7/robots.md
@@ -11,11 +11,11 @@ order: 0
 * [Day 7 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFD5_1RYHtdZroNu?e=Pfdvod)
 * [Asphodel Follows Directions](https://aka.ms/asphodel)
 * Note: More educator information regarding Asphodel's code can be found [here](https://arcade.makecode.com/hour-of-code/educators).
-* [Robots in MakeCode Arcade Handout]()
+* <a href="/unit-3/day-7/robots-makecode-arcade">Robots in MakeCode Arcade Handout</a>
 * [Robots in MakeCode Arcade Handout](https://1drv.ms/w/s!AqsgsTyHBmRBkEG1Su15oOuqnIQV?e=gTRMuB) in Word
 * [Robot Drawing program](https://arcade.makecode.com/75682-33778-96949-32908)
-* [Robot Practice Field]()
-* [Practice Robot Question](/unit-3/day-7/practice-robot-question)
+* <a href="/unit-3/day-7/practice-robot-question">Robot Practice Field</a>
+* <a href="/unit-3/day-7/practice-robot-question">Practice Robot Question</a>
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-3/day-8/integers-part-1.md
+++ b/content/unit-3/day-8/integers-part-1.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 8 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFIIzPX4b2wOA1Bf?e=1IJInU)
-* <a href="/unit-3/day-8/math-operators-variables">Math Operators with Variables</a Handout
+* <a href="/unit-3/day-8/math-operators-variables">Math Operators with Variables</a> Handout
 * [Math Operators with Variables](https://1drv.ms/w/s!AqsgsTyHBmRBkF_FkRqit17O4LnG?e=5ahaot) Handout in Word
 * [arcade.makecode.com](https://arcade.makecode.com)
 * [Button Counter](https://arcade.makecode.com/11167-08585-04692-11299) program (for teacher)

--- a/content/unit-3/day-8/integers-part-1.md
+++ b/content/unit-3/day-8/integers-part-1.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 8 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFIIzPX4b2wOA1Bf?e=1IJInU)
-* [Math Operators with Variables](/unit-3/day-8/math-operators-variables) Handout
+* <a href="/unit-3/day-8/math-operators-variables">Math Operators with Variables</a Handout
 * [Math Operators with Variables](https://1drv.ms/w/s!AqsgsTyHBmRBkF_FkRqit17O4LnG?e=5ahaot) Handout in Word
 * [arcade.makecode.com](https://arcade.makecode.com)
 * [Button Counter](https://arcade.makecode.com/11167-08585-04692-11299) program (for teacher)

--- a/content/unit-3/day-9/integers-part-2.md
+++ b/content/unit-3/day-9/integers-part-2.md
@@ -10,11 +10,11 @@ order: 0
 
 * [Day 9 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFXKjstbzJe5ioSK?e=sUBfFi)
 * [MakeCode Arcade](https://arcade.makecode.com)
-* [My 20% Tip App](/unit-3/day-9/my-20percent-tip-app) handout
+* <a href="/unit-3/day-9/my-20percent-tip-app">My 20% Tip App</a> handout
 * [math+1](https://arcade.makecode.com/50835-80330-42471-08717) (for teacher)
 * [Mod - JavaScript](https://arcade.makecode.com/80718-73341-66614-17701) Code (for teacher)
 * [Mod - Python](https://arcade.makecode.com/88951-80998-23686-31084) Code (for teacher)
-* [Military Time Converter](/unit-3/day-9/military-time-converter) handout
+* <a href="/unit-3/day-9/military-time-converter">Military Time Converter</a> handout
 
 ### Instructional Activities and Classroom Assessments
 


### PR DESCRIPTION
Relative links from markdown will get a duplicated path prefix `makecode-csp` prepended. This quirk is handled by using raw anchors instead `<a href="">...</a>`. Using ``<Link>`` will work also but the styles for `<a>` aren't inherited.

- [x] Change relative links from markdown format to `<a>`.
- [x] Check for other missing links too and fill them in.

Re: https://github.com/microsoft/pxt/issues/8240