### PR TITLE
Unit 4 Relative link fixes and missing links

### DIFF
--- a/content/unit-4/day-1/introduction.md
+++ b/content/unit-4/day-1/introduction.md
@@ -11,7 +11,7 @@ order: 0
 * [Day 1 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj1fg-coGpmueZbKS?e=aPQbsO)
 * [What is artificial intelligence?](https://youtu.be/nASDYRkbQIY)
 * [Blown to Bits Chapter 2](http://www.bitsbook.com/wp-content/uploads/2008/12/chapter2.pdf)
-* [Notetaking template](/unit-4/day-1/notetaking-template)
+* <a href="/unit-4/day-1/notetaking-template">Notetaking template</a>
 * [Notetaking template](https://1drv.ms/w/s!AqsgsTyHBmRBj2MZBmkobnXCZAPa?e=y7ikYU) in Word
 
 ### Instructional Activities and Classroom Assessments
@@ -103,4 +103,4 @@ order: 0
 
 Read pages 4-15 of Blown to Bits Chapter 2.
 Stop at the header "The Parking Garage Knows More Than You Think."
-Use the [Notetaking template](/unit-4/day-1/notetaking-template) to take notes as you read.
+Use the <a href="/unit-4/day-1/notetaking-template">Notetaking template</a> to take notes as you read.

--- a/content/unit-4/day-10/legal-ethical-concerns.md
+++ b/content/unit-4/day-10/legal-ethical-concerns.md
@@ -9,11 +9,11 @@ order: 0
 ### Materials  
 
 * [Day 10 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj2EzljQvy0n4YZUR?e=IWQDKE)
-* [Blown to Bits Chapter 7 Talking Points](/unit-4/day-10/blown-to-bits-chapter)
+* <a href="/unit-4/day-10/blown-to-bits-chapter">Blown to Bits Chapter 7 Talking Points</a>
 * [Blown to Bits Chapter 7 Talking Points](https://1drv.ms/w/s!AqsgsTyHBmRBj1Z7_Wlz5r8R20_p?e=nGnlAI) in Word
 * [LAX Implements Thermal Screening To Scan Passengers For Coronavirus Symptoms | NBC Nightly News](https://youtu.be/rIboxokekE0)
-* [Thermal Cameras article](/unit-4/day-10/thermal-cameras)
-* [Wrongfully Accused article](/unit-4/day-10/wrongfully-accused)
+* <a href="/unit-4/day-10/thermal-cameras">Thermal Cameras article</a>
+* <a href="/unit-4/day-10/wrongfully-accused">Wrongfully Accused article</a>
 
 ### Instructional Activities and Classroom Assessments
 
@@ -46,16 +46,16 @@ IOC-1.B
 * Organize students into groups of 4-5.
 * You can use the [Group Generator](https://arcade.makecode.com/31859-57060-41272-95490) program to randomly sort students.
 * Ask students to use their notes from the Chapter 7 of Blown to Bits to answer the question: What are the challenges of regulating conduct on the Internet.
-*Students can use the [Blown to Bits Chapter 7 Talking Points]() page to guide their discussion.
+*Students can use the <a href="/unit-4/day-10/blown-to-bits-chapter">Blown to Bits Chapter 7 Talking Points</a> page to guide their discussion.
 
 ### 2. Privacy or safety? (15 minutes)
 
 * Play the video.
-* Ask students to read the [Thermal Cameras]() article (or read the article as a class).
+* Ask students to read the <a href="/unit-4/day-10/thermal-cameras">Thermal Cameras article</a> article (or read the article as a class).
 * When everyone is finished, discuss the question: Privacy or Safety? Which one is more important in a pandemic?
 
 ### 3. Bias in algorithms (15 minutes)
 
 * If the other conversations run-over, you can assign this as homework.
-* Ask students to read the [Wrongfully Accused]() article (or read the article as a class).
+* Ask students to read the <a href="/unit-4/day-10/wrongfully-accused">Wrongfully Accused article</a> article (or read the article as a class).
 * When everyone is finished, discuss the question: Should law enforcement use facial recognition in its investigations?

--- a/content/unit-4/day-11/legal-ethical-concerns.md
+++ b/content/unit-4/day-11/legal-ethical-concerns.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials  
 
 * [Day 11 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj2CkoUV8N8YvnglV?e=27CnsT)
-* [Computer Ethics](/unit-4/day-11/computer-ethics)
+* <a href="/unit-4/day-11/computer-ethics">Computer Ethics</a>
 * [What is Creative Commons?](https://youtu.be/dPZTh2NKTm4)
 * [What are Creative Commons Licenses?](https://youtu.be/srVPLrmlBJY)
 * [Smithsonian Open Access: 2.8 Million Images Are Yours to Use](https://youtu.be/B5vC2kweCNk)

--- a/content/unit-4/day-12/debate-preparation.md
+++ b/content/unit-4/day-12/debate-preparation.md
@@ -5,10 +5,10 @@ order: 0
 ---
 
 * [Day 12 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj2KFqEJXJe6sOAYL?e=CkoUV8)
-* [Debate Topics](/unit-4/day-12/debate-topics)
-* [Debating Rules](/unit-4/day-12/debating-rules)
-* [Debate Structure](/unit-4/day-12/debate-structure)
-* [Sample Debate Strategies](/unit-4/day-12/sample-debate-strategies)
+* <a href="/unit-4/day-12/debate-topics">Debate Topics</a>
+* <a href="/unit-4/day-12/debating-rules">Debating Rules</a>
+* <a href="/unit-4/day-12/debate-structure">Debate Structure</a>
+* <a href="(/unit-4/day-12/sample-debate-strategies">Sample Debate Strategies</a>
 
 ### Instructional Activities and Classroom Assessments
 
@@ -29,7 +29,7 @@ order: 0
 * [IOC-2.B](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=130) Explain how computing resources can be protected and can be misused.
 * IOC-2.C
 
-### Essential Knowledge 
+### Essential Knowledge
 
 * [IOC-1.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) to [IOC-1.A.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121)
 * [IOC-1.B.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122) to [IOC-1.B.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122)
@@ -45,39 +45,32 @@ order: 0
 
 ### 1. Organize groups and assign topics (5 minutes)
 
-Organize students into groups of three.
-You can use the Group Generator program to randomly sort students.
-Assign debate topics to groups.
-Give the same topic to two groups.
+* Organize students into groups of three.
+* You can use the Group Generator program to randomly sort students.
+* Assign debate topics to groups.
+* Give the same topic to two groups.
 
- 
+### 2. Explain debate procedure (5 minutes)
 
-### 2. Explain debate procedure (5 minutes) 
+* Explain the procedures for the debate. 
+    * Two groups have the same topic. 
+    * Each student in the team will have a part: 
+        * First speaker
+        * Second speaker
+        * Rebuttal speaker
+    * On the day of their debate, teams will be told if they are for or against the proposition.
+* Explain the timing of the debate.
+* Ask students to review the Debating Rules page.
+* Encourage them to ask any questions they have about the procedure.
 
-Explain the procedures for the debate. 
-Two groups have the same topic. 
-Each student in the team will have a part: 
-First speaker
-Second speaker
-Rebuttal speaker 
-On the day of their debate, teams will be told if they are for or against the proposition. 
-Explain the timing of the debate. 
-Ask students to review the Debating Rules page. 
-Encourage them to ask any questions they have about the procedure.
+### 3. Debate preparation (40 minutes)
 
-### 3. Debate preparation (40 minutes) 
-
-Give students time to prepare. Students should: 
-
-Decide the order they will make their arguments.
-Develop points and arguments for both sides.
-Refer to notes and readings within the unit.
-Conduct additional research.
-
- 
+* Give students time to prepare. Students should:
+    * Decide the order they will make their arguments.
+    * Develop points and arguments for both sides.
+    * Refer to notes and readings within the unit.
+    * Conduct additional research.
 
 ### 4. Homework
 
 * Finish preparing for the debate.
-
- 

--- a/content/unit-4/day-13-15/debates.md
+++ b/content/unit-4/day-13-15/debates.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 13-15 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj2Rk51DuSgVT_KtF?e=bvFvUB)
-* [Debate Structure](/unit-4/day-13-15/debates)
+* <a href="/unit-4/day-13-15/debates">Debate Structure</a>
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-4/day-16/impact-of-computing.md
+++ b/content/unit-4/day-16/impact-of-computing.md
@@ -10,7 +10,7 @@ order: 0
 
 * [Day 16 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkBW3l0eAIhPGXD7D?e=jayMpP)
 * [Impact of a Computing Innovation - Recurring Assignment]() (already handed out to students on Day 11 of Unit 1)
-* [Privacy & Security in Computing Innovations](/unit-4/day-16/privacy-and-security)
+* <a href="/unit-4/day-16/privacy-and-security">Privacy & Security in Computing Innovations</a>
 * [Privacy & Security in Computing Innovations](https://1drv.ms/w/s!AqsgsTyHBmRBkCQ-aRBWwE6GWU4i?e=kjEFL8) in Word
  
 ### Instructional Activities and Classroom Assessments

--- a/content/unit-4/day-16/privacy-and-security.md
+++ b/content/unit-4/day-16/privacy-and-security.md
@@ -4,7 +4,7 @@ metaTitle: "Privacy and Security in Computing Innovations"
 order: 1
 ---
 
-Consult your [Impact of a Computing Innovation - Recurring Assignment](/unit-1/day-11/impact-computing-innovation) page to complete this assignment.
+Consult your <a href="/unit-1/day-11/impact-computing-innovation">Impact of a Computing Innovation - Recurring Assignment</a> page to complete this assignment.
 
 With a partner, enter the computing innovations you have included on your page and presented to the class in the second column, including the one you plan to present today. (Put the name of the person who presented that innovation to the class in the first column.) Then, for the third column, list potential privacy concerns related to each of your computing innovations. In the fourth column, list potential security concerns, and, in the fifth column, list potential storage concerns for each innovation. If you need to conduct research to identify the privacy, security, and storage policies of the computing innovation you are analyzing, please do so.
 

--- a/content/unit-4/day-2/crowdsourcing.md
+++ b/content/unit-4/day-2/crowdsourcing.md
@@ -9,9 +9,9 @@ order: 0
 ### Materials
 
 * [Day 2 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj1nKxEaa5HieLILS?e=Csfifb)
-* [The Scientist in Us All](/unit-4/day-2/scientist-in-us-all)
+* <a href="/unit-4/day-2/scientist-in-us-all">The Scientist in Us All</a>
 * [The Bitcoin Blockchain Explained](https://youtu.be/M_zCjjy59cg)
-* [Notetaking template](/unit-4/day-1/notetaking-template)
+* <a href="/unit-4/day-1/notetaking-template">Notetaking template</a>
 * [Foldit](https://fold.it/)
 * [Eterna](https://eternagame.org/)
 * [Phylo](https://phylo.cs.mcgill.ca/)
@@ -64,7 +64,7 @@ IOC-1.E.2 Science has been affected by using distributed and "citizen science" t
 ### 1. Introduction to Crowdsourcing (10 minutes)
 
 * Define crowdsourcing.
-* Ask students to read * [The Scientist in Us All](/unit-4/day-2/scientist-in-us-all) (or read it out loud as a class).
+* Ask students to read <a href="/unit-4/day-2/scientist-in-us-all">The Scientist in Us All</a> (or read it out loud as a class).
 * Discuss key concepts in the article about Crowdsourcing:
     * What are the benefits?
     * How is this different than the Folding at Home program we learned about when we discussed parallel and distributed computing? How is it similar?

--- a/content/unit-4/day-3/digital-divide-distance-learning.md
+++ b/content/unit-4/day-3/digital-divide-distance-learning.md
@@ -4,7 +4,7 @@ metaTitle: "Digital Divide in Distance Learning"
 order: 1
 ---
 
-![Closing the K-12 Digital Divide in the Age of Distance Learning](content\unit-4\day-3\digital-divide-distance-learning.jpg)
+![Closing the K-12 Digital Divide in the Age of Distance Learning](digital-divide-distance-learning.jpg)
 
 <Tip>
 Read pages 6-15 of the Full Report.

--- a/content/unit-4/day-3/digital-divide.md
+++ b/content/unit-4/day-3/digital-divide.md
@@ -10,11 +10,11 @@ order: 0
 
 * [Day 3 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj1iWYHwq0AMHNnLY?e=NHI9L2)
 * [Cut Out Challenge Worksheet](https://1drv.ms/w/s!AqsgsTyHBmRBj0i5Q6RiRdo0L-QT?e=1lxmxx)
-* [Digital Divide in Distance Learning](/unit-4/day-3/digital-divide-distance-learning) research article
-* [Digital Divide Guided Notes](/unit-4/day-3/digital-divide-guided-notes)
+* <a href="/unit-4/day-3/digital-divide-distance-learning">Digital Divide in Distance Learning</a> research article
+* <a href="/unit-4/day-3/digital-divide-guided-notes">Digital Divide Guided Notes</a>
 * [Digital Divide Guided Notes](https://1drv.ms/w/s!AqsgsTyHBmRBj0lbkW40KU2TJHxw?e=uaq7BL) in Word
-* [Optional: As Covid-19 Closes Schools, the World’s Children Go to Work](/unit-4/day-3/covid-19-closes-schools)
-* [Notetaking template](/unit-4/day-1/notetaking-template)
+* <a href="/unit-4/day-3/covid-19-closes-schools">Optional: As Covid-19 Closes Schools, the World’s Children Go to Work</a>
+* <a href="/unit-4/day-1/notetaking-template">Notetaking template</a>
 
 ### Instructional Activities and Classroom Assessments 
 
@@ -72,14 +72,14 @@ order: 0
         * Number of towers, cost of service, speed of repairs are all dependent on your location.
         * Large, populated cities benefit the most.
         * Rural or small countries with little infrastructure suffer the most.
-* Send students to the [Global Information Technology Report (page 32)](https://www.insead.edu/sites/default/files/assets/dept/globalindices/docs/GITR-2016-report.pdf#page=32) - link is on the [Digital Divide Guided Notes](/unit-4/day-3/digital-divide-guided-notes) page:
+* Send students to the [Global Information Technology Report (page 32)](https://www.insead.edu/sites/default/files/assets/dept/globalindices/docs/GITR-2016-report.pdf#page=32) - link is on the <a href="/unit-4/day-3/digital-divide-guided-notes">Digital Divide Guided Notes</a> page:
 *   Have them compare different countries for their "Networked Readiness."
     * Students should answer: What do you notice about a country's ranking and its income level?
 
 ### 3. Real world example: Digital divide in distance learning (30 minutes) 
 
 * Divide students into small groups of 3-4.
-* Instruct students to read pages 6-15 of Common Sense Media's report on the [Digital Divide in Distance Learning](/unit-4/day-3/digital-divide-distance-learning) and to work together to answer the questions on the [Digital Divide Guided Notes](/unit-4/day-3/digital-divide-guided-notes) page.
+* Instruct students to read pages 6-15 of Common Sense Media's report on the <a href="/unit-4/day-3/digital-divide-distance-learning">Digital Divide in Distance Learning</a> and to work together to answer the questions on the <a href="/unit-4/day-3/digital-divide-guided-notes">Digital Divide Guided Notes</a> page.
 * Give students around 15 minutes to review the document and answer the questions as a team.
 * When students are finished, ask: How can we close the digital divide? In our community? Globally?
 

--- a/content/unit-4/day-4/computing-bias.md
+++ b/content/unit-4/day-4/computing-bias.md
@@ -9,13 +9,13 @@ order: 0
 ### Materials  
 
 * [Day 4 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj1qLEq3BbCTePlS8?e=Ejbio4)
-* [Have You Ever? Reflection](/unit-4/day-4/have-you-ever-reflection)
+* <a href="/unit-4/day-4/have-you-ever-reflection">Have You Ever? Reflection</a>
 * [Introducing the Xbox Adaptive Controller](https://youtu.be/9fcK19CAjWM)
-* [Bias in Technology Article](/unit-4/day-4/bias-in-technology)
+* <a href="/unit-4/day-4/bias-in-technology">Bias in Technology Article</a>
 * [Bias in Technology Article](https://1drv.ms/w/s!AqsgsTyHBmRBj0tShf8toD1rIdXm?e=YwEjZe) PDF
-* [Robot racism? Yes, says a study showing humans' biases extend to robots - CNN](/unit-4/day-4/robot-racism)
-* [Resource for Educator](/unit-4/day-4/resouce-for-educator)
-* [Notetaking template](/unit-4/day-1/notetaking-template)
+* <a href="/unit-4/day-4/robot-racism">Robot racism? Yes, says a study showing humans' biases extend to robots - CNN</a>
+* <a href="/unit-4/day-4/resouce-for-educator">Resource for Educator</a>
+* <a href="/unit-4/day-1/notetaking-template">Notetaking template</a>
 
 ### Instructional Activities and Classroom Assessments
 
@@ -48,7 +48,7 @@ order: 0
     * If their answer to the question is yes, move to the left of the room. 
     * If their answer to the question is no, move to the right of the room. 
 * Prepare students that the questions are thoughtful and may make them feel uncomfortable. 
-* When finished asking each question, ask students to quietly reflect on what they felt/observed during the activity and to write their responses on the [Have You Ever? Reflection](/unit-4/day-4/have-you-ever-reflection) page. 
+* When finished asking each question, ask students to quietly reflect on what they felt/observed during the activity and to write their responses on the <a href="/unit-4/day-4/have-you-ever-reflection">Have You Ever? Reflection</a> page. 
 * Conduct a group discussion about their observations.
 
 ### 2. Computing Bias (10 minutes) 
@@ -62,13 +62,13 @@ order: 0
 ### 3. Lack of Diversity (20 minutes)
 
 * Explain one cause of bias is a lack of diversity in the computer science field.
-* Ask students to read [Bias in Technology](/unit-4/day-4/bias-in-technology).
+* Ask students to read <a href="/unit-4/day-4/bias-in-technology">Bias in Technology Article</a>.
 * Encourage students to brainstorm ideas of how to increase diversity while they wait for classmates to finish reading.
 * Once everyone is finished, ask students to share ideas on how tech companies can increase diversity.
 
 ### 4. Robot Racism (Optional)
 
-* If students finish their discussion about how to increase diversity early, ask students to read the [Robot racism? Yes, says a study showing humans' biases extend to robots - CNN](/unit-4/day-4/robot-racism) article.
+* If students finish their discussion about how to increase diversity early, ask students to read the <a href="/unit-4/day-4/robot-racism">Robot racism? Yes, says a study showing humans' biases extend to robots - CNN</a> article.
 * When they are finished, ask them to answer the following questions:
     * Do you think a lack of diversity influences robot color?
     * How do we change perceptions that influence our biases?

--- a/content/unit-4/day-5/artificial-intelligence.md
+++ b/content/unit-4/day-5/artificial-intelligence.md
@@ -9,11 +9,11 @@ order: 0
 ### Materials
 
 * [Day 5 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj1zwSXDB6nQadfpb?e=7kNYd2)
-* [Biased Algorithms article](/unit-4/day-5/biased-algorithms)
+* <a href="/unit-4/day-5/biased-algorithms">Biased Algorithms article</a>
 * [Computing human bias with AI technology](https://youtu.be/RyanJ2h-9-g)
 * [What is Artificial Intelligence (or Machine Learning)?](https://youtu.be/mJeNghZXtMo)
 * [Are Risk Assessment Algorithms Fair, or Racist?](https://youtu.be/Gi4YeRqfb24)
-* [Optional Resources for Educators](/unit-4/day-5/resources-for-educators)
+* <a href="/unit-4/day-5/resources-for-educators">Optional Resources for Educators</a>
 
 ### Instructional Activities and Classroom Assessments
 
@@ -55,7 +55,7 @@ order: 0
 
 ### 3. Biased Algorithms (15 minutes)
 
-* Ask students to read the [Biased Algorithms](/unit-4/day-5/biased-algorithms) article.
+* Ask students to read the <a href="/unit-4/day-5/biased-algorithms">Biased Algorithms article</a> article.
 * Play the video - [Are Risk Assessment Algorithms Fair, or Racist?](https://youtu.be/Gi4YeRqfb24)
 
 ### 4. Group Brainstorm/Discussion (15 minutes)

--- a/content/unit-4/day-5/resources-for-educators.md
+++ b/content/unit-4/day-5/resources-for-educators.md
@@ -10,7 +10,7 @@ order: 2
 
 https://youtu.be/p-82YeUPQh0
 
-2. Another article regarding AI Bias is [How AI Bias Really Happens](/unit-4/day-5/how-ai-bias-happens).
+2. Another article regarding AI Bias is <a href="/unit-4/day-5/how-ai-bias-happens">How AI Bias Really Happens</a>.
 
 3. [The Social Dilemma](https://www.thesocialdilemma.com/) is a powerful movie about AI algorithm bias in social media, and the addictive qualities of social media platforms. You may assign watching the movie as homework and spend 20 minutes discussing the themes of the movie, and whether or not students agree with some of the conclusions.
 

--- a/content/unit-4/day-6/privacy.md
+++ b/content/unit-4/day-6/privacy.md
@@ -9,13 +9,13 @@ order: 0
 ### Materials 
 
 * [Day 6 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj1uJPCezFpCjkQIn?e=IBsgjC)
-* [Privacy Challenge Activity](/unit-4/day-6/privacy-challenge-activity)
+* <a href="/unit-4/day-6/privacy-challenge-activity">Privacy Challenge Activity</a>
 * [Privacy Challenge Activity](https://1drv.ms/w/s!AqsgsTyHBmRBj0-vqaFJaPFw84hl?e=PI4kBl) in Word 
 * [Sharing Information: A Day in Your Life | Federal Trade Commission](https://youtu.be/O5OsQsB7Hg4)
-* [Blown to Bits Chapter 2 Talking Points](/unit-4/day-6/blown-to-bits-talking-points)
+* <a href="/unit-4/day-6/blown-to-bits-talking-points">Blown to Bits Chapter 2 Talking Points</a>
 * [Blown to Bits Chapter 2 Talking Points](https://1drv.ms/w/s!AqsgsTyHBmRBj01a32gAyjQzrIip?e=y4Qjos) in Word
 * [Homework: Blown to Bits Chapter 5](https://1drv.ms/w/s!AqsgsTyHBmRBj0w2E5kfNEeagzsD?e=Ycgg51)
-* [Homework: Blown to Bits Chapter 5 pages 8-16 Questions](/unit-4/day-6/homework)
+* <a href="/unit-4/day-6/homework">Homework: Blown to Bits Chapter 5 pages 8-16 Questions</a>
 * [Homework: Blown to Bits Chapter 5 pages 8-16 Questions](https://1drv.ms/w/s!AqsgsTyHBmRBj0510oacVZLljaYp?e=S5rZRU) in Word
 
 ### Instructional Activities and Classroom Assessments
@@ -100,16 +100,16 @@ order: 0
 
 ### 3. Personally identifiable information (PII) (5 minutes)
 
-* Play the [Sharing Information: A Day in Your Life | Federal Trade Commission]() video.
+* Play the [Sharing Information: A Day in Your Life | Federal Trade Commission](https://youtu.be/O5OsQsB7Hg4) video.
 * Define PII.
 * Reiterate that they are sharing PII when they place orders, post on social media, use loyalty cards, etc.
 
 ### 4. Small group discussion (15 minutes)
 
 * Organize students into groups of 4-5.
-* You can use the [Group Generator]() program to randomly sort students.
+* You can use the [Group Generator](https://arcade.makecode.com/_CohR5JHEihJL) program to randomly sort students.
 * Ask students to use their notes from the Chapter 2 of Blown to Bits to discuss key concepts they gleaned from the reading.
-* Ask students to use the [Blown to Bits Chapter 2 Talking Points]() page to guide their discussion.
+* Ask students to use the <a href="/unit-4/day-6/blown-to-bits-talking-points">Blown to Bits Chapter 2 Talking Points</a> page to guide their discussion.
 * Tell them that they will share their group's thoughts about the questions in bold on the page in a whole class discussion.
 * Set your timer for 15 minutes.
 

--- a/content/unit-4/day-7/cryptography.md
+++ b/content/unit-4/day-7/cryptography.md
@@ -9,11 +9,11 @@ order: 0
 ### Materials  
 
 * [Day 7 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj15JScpF3V6STW-U?e=eSvl39)
-* [Vigenère Cipher Template](/unit-4/day-7/vigenere-cipher-template)
+* <a href="/unit-4/day-7/vigenere-cipher-template">Vigenère Cipher Template]</a>
 * [Vigenere Cipher Template](https://1drv.ms/w/s!AqsgsTyHBmRBj1HjAyNVKuIml_h6?e=b6GyOY) in Word
 * [Cryptii - Caesar Cipher](https://cryptii.com/pipes/caesar-cipher)
 * [MakeCode Arcade program: Vigenere encode decode](https://arcade.makecode.com/13486-26863-60368-95323)
-* [Homework: Blown to Bits Chapter 5 pages 21-36 Questions](/unit-4/day-7/homework)
+* <a href="/unit-4/day-7/homework">Homework: Blown to Bits Chapter 5 pages 21-36 Questions</a>
 * [Homework: Blown to Bits Chapter 5 pages 21-36 Questions](https://1drv.ms/w/s!AqsgsTyHBmRBj1NXhT3w090ORyPQ?e=JTj1Mf) in Word
 
 ### Instructional Activities and Classroom Assessments 
@@ -73,4 +73,4 @@ Computational Thinking Practice [5.E](https://apcentral.collegeboard.org/pdf/ap-
 ### 5. Homework
 
 * Read pages 21-36 of Blown to Bits Chapter 5.
-* Students should answer the questions on the [Homework: Blown to Bits Chp. 5 p. 21-36 Question]() page.
+* Students should answer the questions on the <a href="/unit-4/day-7/homework">Homework: Blown to Bits Chapter 5 pages 21-36 Questions</a> page.

--- a/content/unit-4/day-8/authentication.md
+++ b/content/unit-4/day-8/authentication.md
@@ -12,7 +12,7 @@ order: 0
 * [Official Trailer: Hackers (1995)](https://youtu.be/qP79h2capFc)
 * [2FA: Two Factor Authentication in 1 minute - For Kids and Parents](https://youtu.be/zvkloHj6aLg)
 * [Protect Your Computer from Malware | Federal Trade Commission](https://youtu.be/XU8PHihT_P4)
-* [One-Pager Brainstorm-Planning Sheet](/unit-4/day-8/one-pager-brainstorm)
+* <a href="/unit-4/day-8/one-pager-brainstorm">One-Pager Brainstorm-Planning Sheet</a>
 * [Cybersecurity Tip Sheets](https://www.cisa.gov/publication/national-cybersecurity-awareness-month-publications)
 
 ### Instructional Activities and Classroom Assessments 

--- a/content/unit-4/day-9/open-source-software.md
+++ b/content/unit-4/day-9/open-source-software.md
@@ -10,11 +10,11 @@ order: 0
 
 * [Day 9 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBj10IUkFt68mqlITi?e=kEb6wL)
 * [What is GitHub?](https://youtu.be/w3jLJU7DT5E)
-* [GitHub Project Analysis](/unit-4/day-9/github-project-analysis)
+* <a href="/unit-4/day-9/github-project-analysis">GitHub Project Analysis</a>
 * [GitHub Project Analysis](https://1drv.ms/w/s!AqsgsTyHBmRBkGE9Oid9RLWXyBFB?e=8zNvbg) in Word
 * [MakeCode Arcade on GitHub](https://github.com/microsoft/pxt-arcade/)
 * [GitHub Directions and Information for Educators](https://1drv.ms/w/s!AqsgsTyHBmRBj1RIei2mWWW3Tlgx?e=yYa2ff)
-* [Teacher Guide for GitHub](/unit-4/day-9/teacher-guide-github)
+* <a href="/unit-4/day-9/teacher-guide-github">Teacher Guide for GitHub]</a>
 * [Homework: Blown to Bits Chapter 7](https://1drv.ms/w/s!AqsgsTyHBmRBj1LXa5OSTrNW64jD?e=hbjpF8)
 
 ### Instructional Activities and Classroom Assessments
@@ -54,7 +54,7 @@ CRD-1.A
 * Explain what GitHub is.
 * Explain the structure of a project or repo.
 * Have students create a GitHub account.
-* Ask them to analyze one of the projects according to the [GitHub Project Analysis](/unit-4/day-9/github-project-analysis) page.
+* Ask them to analyze one of the projects according to the <a href="/unit-4/day-9/github-project-analysis">GitHub Project Analysis</a> page.
 
 ### 3. Share (10 minutes)
 


### PR DESCRIPTION
Relative links from markdown will get a duplicated path prefix `makecode-csp` prepended. This quirk is handled by using raw anchors instead `<a href="">...</a>`. Using ``<Link>`` will work also but the styles for `<a>` aren't inherited.

- [x] Change relative links from markdown format to `<a>`.
- [x] Check for other missing links too and fill them in.

Re: https://github.com/microsoft/pxt/issues/8240