### PR TITLE
Unit 5 Relative link fixes

### DIFF
--- a/content/unit-5/day-1/intro-to-functions.md
+++ b/content/unit-5/day-1/intro-to-functions.md
@@ -11,7 +11,7 @@ order: 0
 * [Day 1 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkHH-DeqCqztjgdPi?e=8ShAIc)
 * [DoSomething sample code](https://makecode.com/_dpa8o38asH3s)
 * [Place Sprite sample code](https://makecode.com/_eHsAWYesxEu7)
-* [Introduction to Functions](/unit-5/day-1/introduction-to-functions) handout in OneNote
+* <a href="/unit-5/day-1/introduction-to-functions">Introduction to Functions</a> handout in OneNote
 * [Introduction to Functions](https://1drv.ms/w/s!AqsgsTyHBmRBkHCcF-mCg8tNfOZi?e=zSt069) handout in Word
 * [Activity: Functions Intro](https://arcade.makecode.com/courses/csintro2/functions/intro)
 
@@ -78,14 +78,14 @@ AAP-3.B.3 The subdivision of a computer program into separate subprograms is cal
 
 ### 3. Learn how to create and call Functions (10 minutes)
 
-* Go to Section A of the Introduction to Functions page.
+* Go to Section A of the <a href="/unit-5/day-1/introduction-to-functions">Introduction to Functions</a> page.
 * Students will use the placeSprite code segment to learn how to create and call functions.
 * Define modularity.
 
 ### 2. Activity: Functions Intro  (20 minutes) 
 
-* Direct students to Section B of the Introduction to Functions page.
-* Task students with completing Tasks 1a - 1b on the Activity: Functions Intro page.
+* Direct students to Section B of the <a href="/unit-5/day-1/introduction-to-functions">Introduction to Functions</a> page.
+* Task students with completing Tasks 1a - 1b on the [Activity: Functions Intro](https://arcade.makecode.com/courses/csintro2/functions/intro) page.
 * If students have time, encourage them to complete the extension activities for 1a and 1b.
 
 ### 5. Reflection/Homework
@@ -98,5 +98,5 @@ If you run out of time, you may also assign this as individual homework. Student
 
 ### 6. Extension activities
 
-* Encourage students who finish early to complete the extension activities on the Introduction to Functions page.
+* Encourage students who finish early to complete the extension activities on the <a href="/unit-5/day-1/introduction-to-functions">Introduction to Functions</a> page.
 * Practice sets are written as JavaScript exercises and can be accomplished using block based code. Students can choose whichever code editor they feel most comfortable with to complete the problems. If needed, students can copy the JavaScript snippet from the problem set, paste it into the JavaScript workspace in MakeCode, then switch back to Block. It has been demonstrated that exposing students to both block and text based code simultaneously makes the transition from block to text more successful.

--- a/content/unit-5/day-12/local-multiplayer.md
+++ b/content/unit-5/day-12/local-multiplayer.md
@@ -10,9 +10,9 @@ order: 0
 
 * [Day 12 PowerPoint deck]()
 * [MultiPlayer Game]() (for teacher)
-* [Multiplayer Handout]()
+* <a href="/unit-5/day-12/multiplayer">Multiplayer Handout</a>
 * [MultiPlayer Handout]() in Word
-* [Activity: Multiplayer]()
+* [Activity: Multiplayer](https://arcade.makecode.com/courses/csintro2/logic/multiplayer)
 
 #### Reference
 
@@ -67,7 +67,7 @@ These are used to test the relationship between two variables, expressions, or v
 
 ### 2. Activity: Multiplayer (40 minutes) 
 
-* Direct students to go to their Multiplayer page.
+* Direct students to go to their <a href="/unit-5/day-12/multiplayer">Multiplayer</a> page.
 * Direct students to complete Tasks 2 through 5.
 * If students have time, encourage them to recreate code segments in JavaScript.
 

--- a/content/unit-5/day-13/intro-tile-maps.md
+++ b/content/unit-5/day-13/intro-tile-maps.md
@@ -10,7 +10,7 @@ order: 0
 
 * [Day 13 PowerPoint deck]()
 * [myMaze]() (for teacher)
-* [Introduction to Tile maps]() handout
+* <a href="/unit-5/day-13/intro-tile-maps">Introduction to Tile maps</a> handout
 * [Introduction to Tile maps]() handout in Word
 * [Activity: Tilemap Intro]() (for teacher reference; activities on this page are included in the PowerPoint)
 * [Activity: Interactions]()

--- a/content/unit-5/day-14/arrays.md
+++ b/content/unit-5/day-14/arrays.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 14 PowerPoint deck]()
-* [Arrays Work handout]()
+* <a href="/unit-5/day-14/arrays-work">Arrays Work</a> handout
 * [Arrays Work]() handout in Word
 * [Activity: Arrays Intro]()
 * [Mad Libs]() (for teacher)
@@ -68,7 +68,7 @@ order: 0
 
 ### 2. Activity:  Create and Modify Arrays (35 minutes)
 
-* Direct students to the [Arrays Work]() page.
+* Direct students to the <a href="/unit-5/day-14/arrays-work">Arrays Work</a> page.
 * Students will go to the [Activity: Arrays Intro]() webpage.
 * Instruct students to complete Tasks 1-2.
 * Encourage students to publish their work and paste the links on their [Arrays Work]() page.

--- a/content/unit-5/day-15/string-arrays.md
+++ b/content/unit-5/day-15/string-arrays.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 15 PowerPoint Deck]()
-* [Arrays of Strings Handout]()
+* <a href="/unit-5/day-15/arrays-of-strings">Arrays of Strings Handout</a>
 * [Arrays of Strings Handout]() in Word
 * [Activity: Arrays of Strings]()
 * [Princess Dialog]()

--- a/content/unit-5/day-16/array-of-sprites.md
+++ b/content/unit-5/day-16/array-of-sprites.md
@@ -38,7 +38,6 @@ Go to [Activity: Arrays of Sprites](https://arcade.makecode.com/courses/csintro2
 
 Go to [Activity: Arrays of Sprites](https://arcade.makecode.com/courses/csintro2/arrays/sprites). Complete Task 3.
 
-
 #### Task 3
 
 1. Start with code from Enemy Follow.

--- a/content/unit-5/day-16/sprite-arrays.md
+++ b/content/unit-5/day-16/sprite-arrays.md
@@ -13,7 +13,7 @@ order: 0
 * [Moving Asteroids 2]()
 * [Fireworks]()
 * [Enemy Follow]()
-* [Array of Sprites Handout]()
+* <a href="/unit-5/day-16/array-of-sprites">Array of Sprites Handout</a>
 * [Array of Sprites Handout]() in Word
 
 ### Instructional Activities and Classroom Assessments
@@ -84,8 +84,8 @@ XEXCLUSIONSTATEMENT(EKAAP-2.O.1): Traversing multiple lists at the same time usi
 
 ### 2. Activity: Arrays of Sprites (40 minutes)
 
-* Direct students to the Array of Sprites page.
-* Students will go to Activity: Arrays of Sprites (makecode.com).
+* Direct students to the <a href="/unit-5/day-16/array-of-sprites">Array of Sprites</a> page.
+* Students will go to [Activity: Arrays of Sprites](https://arcade.makecode.com/courses/csintro2/arrays/string) (makecode.com).
 * Instruct students to complete Practice tasks 1, 2 and 3.
 * Encourage students to publish their work and paste the links on their Array of Sprites page. 
 

--- a/content/unit-5/day-17/arrays-practice.md
+++ b/content/unit-5/day-17/arrays-practice.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 17 PowerPoint Deck]()
-* [Arrays Practice Programs]() Handout
+* <a href="/unit-5/day-17/arrays-practice-programs">Arrays Practice Programs</a> Handout
 * [Arrays Practice Programs]() Handout in Word
 
 ### Instructional Activities and Classroom Assessments
@@ -83,10 +83,10 @@ XEXCLUSIONSTATEMENT(EKAAP-2.O.1): Traversing multiple lists at the same time usi
 
 ### 2. Activity:  Arrays practice (30 minutes)
 
-* Direct students to the  Arrays Practice Programs page.
-* Students will go to Microsoft MakeCode Arcade.
+* Direct students to the <a href="/unit-5/day-17/arrays-practice-programs">Arrays Practice Programs</a> page.
+* Students will go to [Microsoft MakeCode Arcade](https://arcade.makecode.com).
 * Instruct students to complete Practice tasks 1, 2, and 3.
-* Encourage students to publish their work and paste the links on their Arrays Practice Programs page.
+* Encourage students to publish their work and paste the links on their <a href="/unit-5/day-17/arrays-practice-programs">Arrays Practice Programs</a> page.
 
 ### 3. Extension
 

--- a/content/unit-5/day-18/sorting-arrays.md
+++ b/content/unit-5/day-18/sorting-arrays.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 18 PowerPoint deck]()
-* [Sorting Arrays Practice]() handout
+* <a href="/unit-5/day-18/sorting-arrays-practice">Sorting Arrays Practice</a> handout
 * [Sorting Arrays Practice]() handout in Word
 * [Sorting Algorithms]()
 
@@ -80,10 +80,10 @@ XEXCLUSIONSTATEMENT(EKAAP-2.O.1): Traversing multiple lists at the same time usi
 
 ### 3. Activity: Sorting Algorithm (20 minutes)
 
-Direct students to the [Sorting Arrays Practice]() page.
+Direct students to the <a href="/unit-5/day-18/sorting-arrays-practice">Sorting Arrays Practice</a> page.
 Instruct students to create a bubble sorting algorithm in MakeCode (NOTE: this is a challenging assignment. It's okay if a majority of students don't get it. Feel free to walk through the solution code with them.)
 Students will have the opportunity to complete this activity in the next lesson.
-Encourage students to publish their work and paste the links on their [Sorting Arrays Practice]() page.
+Encourage students to publish their work and paste the links on their <a href="/unit-5/day-18/sorting-arrays-practice">Sorting Arrays Practice</a> page.
 
 ### 4. Reflection/Homework
 

--- a/content/unit-5/day-2/parameters.md
+++ b/content/unit-5/day-2/parameters.md
@@ -8,20 +8,20 @@ order: 0
 
 ### Materials
 
-* [Day 2 PowerPoint deck]()
-* [DoSomething sample code]()
-* [Draw Rectangle]()
-* [Draw Rectangle Mod]() (for teacher)
-* [Robot Functions code sample]()
-* [Robot Draw Side solution]()
-* [Print Console 1 code sample]()
-* [Print Console 2 code sample]()
-* [Decisions Solution]()
-* [Change by Five code sample]()
-* [Writing Functions with Parameters handout]()
-* [Writing Functions with Parameters]() handout in Word
-* [Activity: Parameters]()
-* [Problem Set: Parameters]()
+* [Day 2 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkG-ueZhGpOgZxaM2?e=7QGVhJ)
+* [DoSomething sample code](https://makecode.com/_dpa8o38asH3s)
+* [Draw Rectangle](https://makecode.com/_6P5MaCAFRW8K)
+* [Draw Rectangle Mod](https://makecode.com/_2JR5dXh096Ls) (for teacher)
+* [Robot Functions code sample](https://makecode.com/_1yPFy3KrfMvJ)
+* [Robot Draw Side solution](https://makecode.com/_MomAAsF3zCMU)
+* [Print Console 1 code sample](https://makecode.com/_bmpVwKCqLLKw)
+* [Print Console 2 code sample](https://makecode.com/_gCuKfET8XeiJ)
+* [Decisions Solution](https://makecode.com/_CyfY2f0puRVC)
+* [Change by Five code sample](https://makecode.com/_67EX2zKJfDVH)
+* <a href="/unit-5/day-2/writing-functions-parameters">Writing Functions with Parameters handout</a>
+* [Writing Functions with Parameters](https://1drv.ms/w/s!AqsgsTyHBmRBkG4gPxl1CKxXuXVg?e=fd3Bcj) handout in Word
+* [Activity: Parameters](https://arcade.makecode.com/courses/csintro3/functions/parameters)
+* [Problem Set: Parameters](https://arcade.makecode.com/courses/csintro3/functions/parameters-problems)
 
 ### Instructional Activities and Classroom Assessments
 
@@ -109,7 +109,7 @@ which is used to define a procedure that takes zero or more arguments. The proce
 
 ### 3. Writing functions with parameters  (25 minutes)
 
-* Direct students to the [Writing Functions with Parameters]() page.
+* Direct students to the <a href="/unit-5/day-2/writing-functions-parameters">Writing Functions with Parameters</a> page.
 * Task students with completing Tasks 1 - 3 on the [Activity: Parameters](https://arcade.makecode.com/courses/csintro3/functions/parameters) page.
 * If students have time, encourage them to complete the extension activities.
 

--- a/content/unit-5/day-20-27/culminating-project.md
+++ b/content/unit-5/day-20-27/culminating-project.md
@@ -9,15 +9,15 @@ order: 0
 ### Materials
 
 * [Days 20-27 PowerPoint deck]()
-* [Planning Your Unit 5 Project]() handout
+* <a href="content\unit-5\day-20-27\planning-your-project.md">Planning Your Unit 5 Project</a> handout
 * [Planning Your Unit 5 Project]() handout in Word
-* [Project Requirements & Responses]() handout
+* <a href="/unit-5/day-20-27/project-requirements-responses">Project Requirements & Responses</a> handout
 * [Project Requirements & Responses]() handout in Word
-* [Unit 5 Project Rubric]()
+* <a href="/unit-5/day-20-27/project-rubric">Unit 5 Project Rubric</a>
 * [Unit 5 Project Rubric]() in Word
-* [Gallery Walk Feedback Form]()
+* <a href="/unit-5/day-20-27/gallery-walk">Gallery Walk Feedback Form</a>
 * [Gallery Walk Feedback Form]() in Word
-* [Presentation Checklist]()
+* <a href="/unit-5/day-20-27/presentation-checklist">Presentation Checklist</a>
 * [Presentation Checklist]() in Word
 
 ### Instructional Activities and Classroom Assessments 
@@ -94,13 +94,13 @@ The project is a review of the essential knowledge skills covered in this unit.
 #### 1. Introduction to the project (10 minutes) 
 
 * Explain to students the requirements for the collaborative project.
-* Provide students the [Project Requirements & Responses]() page and the [Unit 5 Project Rubric]() and give them 5 minutes to review both documents.
+* Provide students the <a href="/unit-5/day-20-27/project-requirements-responses">Project Requirements & Responses</a> page and the <a href="/unit-5/day-20-27/project-rubric">Unit 5 Project Rubric</a> and give them 5 minutes to review both documents.
 * Answer any questions students have regarding the project.
 
 #### 2. Brainstorm ideas (15 minutes)
 
 * Task students with brainstorming ideas for their project.
-* Encourage them to respond to prompts on the [Planning Your Unit 5 Project]() page to help generate ideas.
+* Encourage them to respond to prompts on the <a href="content\unit-5\day-20-27\planning-your-project.md">Planning Your Unit 5 Project</a> page to help generate ideas.
 
 #### 3. Pair and share (15 minutes)
 
@@ -328,7 +328,7 @@ The project is a review of the essential knowledge skills covered in this unit.
 #### 2. Finalize submissions and turn in project (10 minutes)
 
 * Task students with:
-    * Publishing their game and copying the link to the [Project Requirements & Responses]() page.
+    * Publishing their game and copying the link to the <a href="/unit-5/day-20-27/project-requirements-responses">Project Requirements & Responses</a> page.
     * Creating a screencast of their game being played.
     * Creating a screenshot of their program and label each type of algorithm implementation.
     * Each partner needs to add the link and the screenshot to their project responses page.

--- a/content/unit-5/day-20-27/planning-your-project.md
+++ b/content/unit-5/day-20-27/planning-your-project.md
@@ -4,7 +4,7 @@ metaTitle: 'Planning Your Unit 5 Project'
 order: 1
 ---
 
-:white_large_square: [Review Project Requirements & Responses]() and [Unit 5 Project Rubric]().
+:white_large_square: Review <a href="/unit-5/day-20-27/project-requirements-responses">Project Requirements & Responses</a> and <a href="/unit-5/day-20-27/project-rubric">Unit 5 Project Rubric</a>.
 
 :white_large_square: Brainstorm ideas for your project. Ask yourself the following questions:
 

--- a/content/unit-5/day-28/can-computers-solve.md
+++ b/content/unit-5/day-28/can-computers-solve.md
@@ -9,9 +9,9 @@ order: 0
 ### Material
 
 * [Day 28 PowerPoint deck]()
-* [Computer Problem Solving]() handout
+* <a href="/unit-5/day-28/computer-problem-solving">Computer Problem Solving</a> handout
 * [Computer Problem Solving]() handout in Word
-* [Resource Links]() (for teacher, but can be shared with students if you prefer)
+* <a href="/unit-5/day-28/resource-links">Resource Links</a> (for teacher, but can be shared with students if you prefer)
 
 ### Instructional Activities and Classroom Assessments
 
@@ -70,7 +70,7 @@ X EXCLUSION STATEMENT (EK AAP-4.B.2): Determining whether a given problem is und
     * Simulations
     * Heuristic algorithms
     * Undecidable problem
-* Encourage students to add the summaries of their research on their group's [Computer Problem Solving]() page.
+* Encourage students to add the summaries of their research on their group's <a href="/unit-5/day-28/computer-problem-solving">Computer Problem Solving</a> page.
 * Each group member will share their finding with the class.
 
 ### 3. Reflection/Homework

--- a/content/unit-5/day-3/return-values.md
+++ b/content/unit-5/day-3/return-values.md
@@ -12,7 +12,7 @@ order: 0
 * [Full Name sample code]()
 * [Series Sum Solution]() (for teacher)
 * [Pizza Allowance code sample]()
-* [Writing Functions with Return Values]() Handout
+* <a href="/unit-5/day-3/writing-functions-return-values">Writing Functions with Return Values</a> Handout
 * [Writing Functions with Return Values]() Handout in Word
 * [Activity: Return Values]()
 * [Problem Set: Returns]()
@@ -73,9 +73,9 @@ which is used to define a procedure that takes zero or more arguments. The proce
 
 ### 3. Activity: Writing Functions with Parameters (25 minutes)
 
-* Direct students to go their Writing Functions with Return Values page.
+* Direct students to go their <a href="/unit-5/day-3/writing-functions-return-values">Writing Functions with Return Values</a> page.
 * Task students with completing all of the tasks on the page:
-    * Tasks 1 - 2 using the guide on the Activity: Return Values webpage.
+    * Tasks 1 - 2 using the guide on the [Activity: Return Values](https://arcade.makecode.com/courses/csintro3/functions/returns) webpage.
     * Task 3.
     * If students have time, encourage them to code in JavaScript.
 
@@ -90,5 +90,5 @@ If you run out of time, you may also assign this as individual homework. Student
 
 ### 5. Homework
 
-* Task students with completing the activities on the Problem Set: Returns webpage for homework.
+* Task students with completing the activities on the [Problem Set: Returns](https://arcade.makecode.com/courses/csintro3/functions/returns-problems) webpage for homework.
 * _Practice sets are written as JavaScript exercises and can be accomplished using block based code. Students can choose whichever code editor they feel most comfortable with to complete the problems. If needed, students can copy the JavaScript snippet from the problem set, paste it into the JavaScript workspace in MakeCode, then switch back to Block. It has been demonstrated that exposing students to both block and text based code simultaneously makes the transition from block to text more successful._

--- a/content/unit-5/day-4/using-extensions.md
+++ b/content/unit-5/day-4/using-extensions.md
@@ -9,7 +9,7 @@ order: 0
 * [Day 4 PowerPoint deck]()
 * [Football]() (for teacher)
 * [My Extension]() (for teacher)
-* [Making and Using Extensions]() handout
+* <a href="/unit-5/day-4/making-using-extensions">Making and Using Extensions</a> handout
 * [Making and Using Extensions]() handout in Word
 * [Activity: Making and Using Extensions]()
 * [Resource: Defining Blocks]()
@@ -61,7 +61,7 @@ order: 0
 
 ### 3. Activity: Writing functions with parameters (30 minutes)
 
-* Direct students to their [Making and Using Extensions]() page.
+* Direct students to their <a href="/unit-5/day-4/making-using-extensions">Making and Using Extensions</a> page.
 * Task students with completing Tasks 1, 2a, and 2b.
 * If students have time, encourage them to complete the extensions activities for both tasks (coding in JavaScript).
 

--- a/content/unit-5/day-5/boolean-statements-expressions.md
+++ b/content/unit-5/day-5/boolean-statements-expressions.md
@@ -37,7 +37,7 @@ NOT Left is Right:
 
 ### C. Go to Activity: Boolean Statements and Expressions. Complete student tasks 3-4.
 
-[Boolean Statements and Expressions]()
+[Boolean Statements and Expressions](https://arcade.makecode.com/courses/csintro2/logic/booleans)
 
 #### Task 3
 

--- a/content/unit-5/day-5/complex-conditionals.md
+++ b/content/unit-5/day-5/complex-conditionals.md
@@ -13,7 +13,7 @@ order: 0
 * [Hungry Mod]() (for teacher)
 * [NOT Left]() (for teacher)
 * [Quadrants]() (for teacher)
-* [Boolean Statements and Expressions]() handout
+* <a href="/unit-5/day-5/boolean-statements-expressions">Boolean Statements and Expressions</a> handout
 * [Boolean Statements and Expressions]() handout in Word
 * [Activity: Boolean Statements and Expressions](https://arcade.makecode.com/courses/csintro2/logic/booleans)
 
@@ -88,7 +88,7 @@ These are used to test the relationship between two variables, expressions, or v
 
 ### 3. Boolean practice (25 minutes) 
 
-* Go to [Boolean Statements and Expressions]().
+* Go to <a href="/unit-5/day-5/boolean-statements-expressions">Boolean Statements and Expressions</a>.
 * Task students with completing Tasks 3 and 4.
 * If students have time, encourage them to complete the extensions activities. 
 

--- a/content/unit-5/day-6/logic-validating-user-input.md
+++ b/content/unit-5/day-6/logic-validating-user-input.md
@@ -9,11 +9,11 @@ order: 0
 ### Materials
 
 * [Day 6 PowerPoint deck]()
-* [Validating User Input]() handout
+* <a href="/unit-5/day-6/validating-user-input.md">Validating User Input</a> handout
 * [Validating User Input]() handout in Word
 * [winnerWinner](https://makecode.com/_0F00C66wK3Di) (for teacher)
 * [helloFriend](https://makecode.com/_amzHh6iF7Eyg) (for teacher)
-* [Activity: User Input and String Logic]()
+* [Activity: User Input and String Logic](https://arcade.makecode.com/courses/csintro2/logic/user-input)
 
 Additional references:
 
@@ -35,11 +35,11 @@ Learning Objectives
 * [AAP-2.D]() Evaluate expressions that manipulate strings. 4.B
 * [AAP-2.E]() For relationships between two variables, expressions, or values:  
     * a. Write expressions using relational operators. 2.B  
-    * b. Evaluate expressions that use relational operators.  4.B
+    * b. Evaluate expressions that use relational operators. 4.B
 * [AAP-2.F]() For relationships between Boolean values: a. Write expressions using logical operators. 2.B b.  Evaluate expressions that use logic operators. 4.B
 * [AAP-2.H]() For selection:
     * a. Write conditional statements. 2.B
-    * b. Determine the result of conditional statements.  4.B
+    * b. Determine the result of conditional statements. 4.B
 * CRD-2.C Identify input(s) to a program
 
 ### Essential Knowledge
@@ -84,7 +84,7 @@ These are used to test the relationship between two variables, expressions, or v
 
 ### 3. Activity: User input and string logic (25 minutes)
 
-* Direct students to go to [Validating User Input]() of the page.
+* Direct students to go to <a href="/unit-5/day-6/validating-user-input.md">Validating User Input</a> of the page.
 * Task students with completing Task 1, Task 2, and Task 2 Challenge.
 * If students have time, encourage them to recreate code segments in JavaScript.
 

--- a/content/unit-5/day-7/logic-in-loops-unplugged.md
+++ b/content/unit-5/day-7/logic-in-loops-unplugged.md
@@ -12,7 +12,7 @@ order: 1
 * Cut out words:
     * You can create your own simple sentences, or
     * You can use the ones on this document: [Simple Sentences]().
-* A [Sentence Puzzles]() page for each group. ([Sentence Puzzles Word document]())
+* A <a href="/unit-5/day-7/sentence-puzzles">Sentence Puzzles</a> page for each group. ([Sentence Puzzles Word document]())
 
 ## Before class
 
@@ -24,7 +24,7 @@ order: 1
 ## In class
 
 * Form groups of 2 to 3 students each.
-* Distribute one die to each student group. Use [virtual die]() if that is more convenient.
+* Distribute one die to each student group. Use [virtual die](https://www.random.org/dice/) if that is more convenient.
 * Distribute an A, B, and C pile of cards to each group.
 * Explain this process:
     * Roll the die. The die will determine which pile to select a card from:
@@ -34,7 +34,7 @@ order: 1
     * If you roll a 3 or 5, roll again.
     * It is possible to take a card from one of the piles more than once.
     * Keep rolling until you have three cards. 
-    * When you have three cards, write a complete sentence that incorporates the words on the cards drawn. Use all 3 words. Students can use the [Sentence Puzzles]() page to keep track of their sentences. 
+    * When you have three cards, write a complete sentence that incorporates the words on the cards drawn. Use all 3 words. Students can use the <a href="/unit-5/day-7/sentence-puzzles">Sentence Puzzles</a> page to keep track of their sentences. 
 * When each group has a sentence, ask groups to show the words they selected and read their sentence.  
 * Repeat this steps of rolling the die, getting cards, and writing a sentence several times until the students are comfortable with the process.
 * When the students are comfortable with the process, instruct them to describe the steps of the process using the concepts and terms used when discussing loops and logic. 
@@ -51,7 +51,7 @@ IF dice is <5: take a card from pile C
 Else roll again 
 ```
 
-* Students can use the [Sentence Puzzles]() page to document their work together. 
+* Students can use the <a href="/unit-5/day-7/sentence-puzzles">Sentence Puzzles</a> page to document their work together. 
 * Extension: modify the game play rules to include:
     * And
     * Or

--- a/content/unit-5/day-7/logic-in-loops.md
+++ b/content/unit-5/day-7/logic-in-loops.md
@@ -9,10 +9,10 @@ order: 0
 ### Materials  
 
 * [Day 7 PowerPoint Deck]()
-* [Logic in Loops Handout]()
+* <a href="/unit-5/day-7/logic-in-loops-activity">Logic in Loops Handout</a>
 * [Logic in Loops Handout]() in Word
-* [Logic in Loops Unplugged]()
-* [Sentence Puzzles]()
+* <a href="/unit-5/day-7/logic-in-loops-unplugged">Logic in Loops Unplugged</a>
+* <a href="/unit-5/day-7/sentence-puzzles">Sentence Puzzles</a>
 * Decks of cards
 * Dice
 * Tape 
@@ -85,7 +85,7 @@ These are used to test the relationship between two variables, expressions, or v
 
 ###  4. Activity: User Input and String Logic (25 minutes)
 
-* Direct students to go to their  Activity: Logic in Loops page.
+* Direct students to go to their <a href="/unit-5/day-7/logic-in-loops-activity">Activity: Logic in Loops</a> page.
 * Direct students to complete Tasks 1 and 2.
 * If students have time, encourage them to use functions and parameters in the fireball game to make it easier to manage and to recreate code segments in JavaScript.
 

--- a/content/unit-5/day-8-11/collaborative-coding.md
+++ b/content/unit-5/day-8-11/collaborative-coding.md
@@ -9,11 +9,11 @@ order: 0
 ### Materials
 
 * [Days 8-11 PowerPoint deck]()
-* [Planning Your Program handout]()
+* <a href="/unit-5/day-8-11/planning-your-program">Planning Your Program handout</a>
 * [Planning Your Program handout]() in Word
-* [Project Requirements & Responses]() handout
+* <a href="/unit-5/day-8-11/project-requirements-responses">Project Requirements & Responses</a> handout
 * [Project Requirements & Responses]() handout in Word
-* [Collaborative Project Rubric]()
+* <a href="/unit-5/day-8-11/collaborative-project-rubric">Collaborative Project Rubric</a>
 * [Collaborative Project Rubric]() in Word
 
 * References:
@@ -67,7 +67,7 @@ The project is a review of the essential knowledge skills covered in this unit.
 #### 2. Brainstorm ideas (15 minutes) 
 
 1. Task students with brainstorming ideas for their project.
-2. Encourage them to respond to prompts on the [Planning Your Program]() page to help generate ideas.
+2. Encourage them to respond to prompts on the <a href="/unit-5/day-8-11/planning-your-program">Planning Your Program handout</a> page to help generate ideas.
 
 #### 3. Pair and share (15minutes)
 

--- a/content/unit-5/day-8-11/planning-your-program.md
+++ b/content/unit-5/day-8-11/planning-your-program.md
@@ -4,7 +4,7 @@ metaTitle: 'Planning Your Program'
 order: 1
 ---
 
-:white_large_square: [Review Project Requirements & Responses]() and [Collaborative Project Rubric](). 
+:white_large_square: Review <a href="/unit-5/day-8-11/project-requirements-responses">Project Requirements & Responses</a> and <a href="/unit-5/day-8-11/collaborative-project-rubric">Collaborative Project Rubric</a>. 
 
 :white_large_square: Brainstorm ideas for your project. Ask yourselves the following questions: 
 

--- a/content/unit-6/day-1/intro-data-analysis.md
+++ b/content/unit-6/day-1/intro-data-analysis.md
@@ -9,10 +9,10 @@ order: 0
 ### Materials
 
 * [Day 1 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj2oFvJ-UEz9gsIDY?e=GyAPFm)
-* [GED VIZ - Tell Your Own Story](/unit-6/day-1/tell-your-own-story)
+* <a href="/unit-6/day-1/tell-your-own-story">GED VIZ - Tell Your Own Story</a>
 * [GED VIZ site](https://viz.ged-project.de/)
 * [GED VIZ Computer Import/Export data](https://viz.ged-project.de/edit/6908?lang=en)
-* [A Tale of Economies Activity](/unit-6/day-1/tale-of-economies) page
+* <a href="/unit-6/day-1/tale-of-economies">A Tale of Economies Activity</a> page
 * [GED VIZ US Recession data](https://viz.ged-project.de/edit/7028?lang=en)
 * [GED VIZ Global Recession data](https://viz.ged-project.de/edit/7038?lang=en)
 * [GED VIZ | Tutorial Video](https://youtu.be/FNUT-KwKd58) (English Version)
@@ -33,7 +33,7 @@ order: 0
 
 ### Learning Objectives
 
-* [* DAT-2.A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Describe what information can be extracted from data.
+* [DAT-2.A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Describe what information can be extracted from data.
 * DAT-2.D
 * DAT-2.E
 
@@ -54,3 +54,55 @@ order: 0
 * DAT-2.E.3
 * DAT-2.E.4
 * DAT-2.E.5
+
+## Details
+
+### 0. Before class
+
+* Create a section in the Collaboration Space of your Class OneNote notebook titled "GED VIZ Stories."
+* Copy the <a href="/unit-6/day-1/tell-your-own-story">GED VIZ - Tell Your Own Story</a> page to the GED VIZ Stories section and duplicate it so that you have enough pages for each small group.
+* Number the pages so when you assign the groups, they know which page number they will use.
+
+### 1. Introduction to Data Analysis and Visualization (15 minutes)
+
+* Define Data Analysis.
+* Show students the GED Viz visual of the computer import/export data.
+* Explain the trend we see with this data.
+* Play the GED VIZ Tutorial video.
+* Discuss the goal of GED VIZ.
+
+### 2. A Tale of Economies (5 minutes)
+
+* Discuss the Great Recession of 2008:
+    * Play the video
+    * Explain the global impact
+
+### 3. Group activity: Analyze Impact of the Recession (10 minutes) 
+
+* Ask students to use the <a href="/unit-6/day-1/tale-of-economies">A Tale of Economies Activity</a> page to guide their exploration of two different GED VIZ slide shows.
+* Ask students to work in pairs to review the data for each slide show and answer the questions on the page.
+* You can use the <a href="https://makecode.com/CohR5JHEihJL">Group Generator</a> program to randomly sort students.
+* Give students five minutes to explore; if they finish before five minutes, you can move on to the next step.
+* Discuss the data together:
+    * What were your observations from looking at the data?
+    * Why do you think oil trade bounced back the fastest?
+    * Why do you think iron/steel was the slowest to recover?
+    * Why do you think Greece, Latvia, and Iceland never fully recovered?
+
+### 4. Group activity: Tell Your Own Story (15 minutes)
+
+* Ask students to work with a teammate to do the following:
+    * Go to the <a href="/unit-6/day-1/tell-your-own-story">GED VIZ - Tell Your Own Story</a> page.
+    * Select a topic they will analyze with the GED VIZ tool:
+        * Students can find topic ideas on the <a href="/unit-6/day-1/tell-your-own-story">GED VIZ - Tell Your Own Story</a> page.
+    * Create a slide show for the data they are analyzing.
+    * Write a short explanation of:
+        * What the slide show depicts, and
+        * What you believe the data is telling us.
+* Ask students to add the link to their slide show and their analysis to a OneNote page in the collaboration space.
+* Give students 15 minutes to complete the task.
+* If students finish early, encourage students to look at other group's analysis for a couple of minutes.
+
+### 5. Homework
+
+* If a group does not finish the Tell Your Own Story activity, they need to finish it for homework.

--- a/content/unit-6/day-1/tale-of-economies.md
+++ b/content/unit-6/day-1/tale-of-economies.md
@@ -6,7 +6,7 @@ order: 1
 
 Work with a partner to explore these two slide shows to see how the Great Recession of 2008 impacted the world.
 
-The first slide show from [GEDVIZ]() tracks trade for iron and steel, petroleum oil, and cars between the United States, the United Kingdom, Germany, Japan, Canada, and Mexico.
+The first slide show from [GEDVIZ](https://viz.ged-project.de/edit/6956?lang=en) tracks trade for iron and steel, petroleum oil, and cars between the United States, the United Kingdom, Germany, Japan, Canada, and Mexico.
 
 Look through the slide show by selecting the labels on the right to see the progression of trade over time. Answer the following questions:
 
@@ -22,7 +22,7 @@ Look through the slide show by selecting the labels on the right to see the prog
 
 5. How does this slide show help you see the impact of the Great Recession on the United States?
 
-In the second slide show from [GEDVIZ]() tracks the trade for iron/steel and cars for Greece, Latvia, and Iceland. Although the "connections" (arrows between the countries) do not demonstrate a great deal, the bars for each country provide a visual of the decline in each economy.
+In the second slide show from [GEDVIZ](https://viz.ged-project.de/edit/6955?lang=en) tracks the trade for iron/steel and cars for Greece, Latvia, and Iceland. Although the "connections" (arrows between the countries) do not demonstrate a great deal, the bars for each country provide a visual of the decline in each economy.
 
 Look through the slide show by selecting the labels on the right to see the progression of the decline over time. Answer the following questions:
 

--- a/content/unit-6/day-2/what-is-data-science.md
+++ b/content/unit-6/day-2/what-is-data-science.md
@@ -9,13 +9,13 @@ order: 0
 ### Materials 
 
 * [Day 2 PowerPoint deck]()
-* [Data Research Project]()
+* <a href="/unit-6/day-2/data-research-project">Data Research Project</a>
 * [Data Research Project]() in Word 
-* [Data Science Process Checklist]()
+* <a href="/unit-6/day-2/data-science-process">Data Science Process Checklist</a>
 * [Data Science Process Checklist]() in Word 
-* [Data Research Brainstorm]()
+* <a href="/unit-6/day-2/data-research-brainstorm">Data Research Brainstorm</a>
 * [Data Research Brainstorm]() in Word 
-* [Research Prompt Ideas]()
+* <a href="/unit-6/day-2/research-prompt-ideas">Research Prompt Ideas</a>
 * [Research Prompt Ideas]() in Word
 * [What is Data Science? | Great Learning]()
 
@@ -63,7 +63,7 @@ order: 0
 
 ### 0. Before class 
 
-* Suggestion: Add specific days that students will complete each step of the project on the [Data Research Project]() page.
+* Suggestion: Add specific days that students will complete each step of the project on the <a href="/unit-6/day-2/data-research-project">Data Research Project</a> page.
 
 ### 1. Share GED VIZ "Stories" (10 minutes)
 
@@ -98,9 +98,9 @@ order: 0
     * Select one of those topics to create a survey and collect data on the topic.
     * Analyze the data.
     * Create a visual representation of the data.
-* Give students the [Data Science Process Checklist]() and the [Data Research Brainstorm]() pages to guide their work.
+* Give students the <a href="/unit-6/day-2/data-science-process">Data Science Process Checklist</a> and the <a href="/unit-6/day-2/data-research-brainstorm">Data Research Brainstorm</a> pages to guide their work.
 * Ask students to brainstorm ideas for questions they want to answer with a research project.
-* Send students to the [Research Prompt Ideas]() page for ideas (or a choice).
+* Send students to the <a href="/unit-6/day-2/research-prompt-ideas">Research Prompt Ideas</a> page for ideas (or a choice).
 * Everyone must have a different topic.
 
 ### 4. Homework 

--- a/content/unit-6/day-3/data-collection.md
+++ b/content/unit-6/day-3/data-collection.md
@@ -10,9 +10,9 @@ order: 0
 
 * [Day 3 PowerPoint deck]()
 * [Data Science Process Checklist]()
-* [Bias in Surveys Activity]()
-* [Examples of Biased Survey Questions]()
-* [Survey Rubric]()
+* <a href="/unit-6/day-3/bias-in-surveys-activity">Bias in Surveys Activity</a>
+* <a href="/unit-6/day-3/examples-biased-surveys-questions">Examples of Biased Survey Questions</a>
+* <a href="/unit-6/day-3/survey-rubric">Survey Rubric</a>
 * [Survey Rubric]() in Word
 
 ### Instructional Activities and Classroom Assessments
@@ -47,8 +47,8 @@ order: 0
     * Assign each student a number a slip of paper and select from those numbers to see who "wins".
     * Another option is to allow students who have the same question idea to work together as a pair.
 * For the Bias in Survey Questions activity:
-    * Print 10 copies of the [Bias in Surveys Activity]() page, or 
-    * Add the [Bias in Surveys Activity]() page to the Collaboration page. 
+    * Print 10 copies of the <a href="/unit-6/day-3/bias-in-surveys-activity">Bias in Surveys Activity</a> page, or 
+    * Add the <a href="/unit-6/day-3/bias-in-surveys-activity">Bias in Surveys Activity</a> page to the Collaboration page. 
     * Be prepared to assign each example of survey bias to one of the 10 groups that are formed when you reach this part of the lesson: 
         * You can write each example on a slip of paper to give the students, or 
         * You can simply walk around the room and tell each group a number 1-10.
@@ -88,7 +88,7 @@ order: 0
     * Students should work with the peers sitting closest to them.
     * Organize 10 groups.
     * Assign each group one of the 10 examples of survey bias.
-    * Ask students to follow the directions on the [Bias in Surveys Activity]() page.
+    * Ask students to follow the directions on the <a href="/unit-6/day-3/bias-in-surveys-activity">Bias in Surveys Activity</a> page.
     * After a few minutes, ask each group to share what they learned about their example.
 * Give students tips on creating a good survey.
 
@@ -96,7 +96,7 @@ order: 0
 
 * Students will begin crafting their survey questions in class.
 * They will finish creating those questions for homework.
-* Share the [Survey Rubric]() with students so they know how you will grade their surveys.
+* Share the <a href="/unit-6/day-3/survey-rubric">Survey Rubric</a> with students so they know how you will grade their surveys.
 
 ### 7. Homework 
 


### PR DESCRIPTION
Relative links from markdown will get a duplicated path prefix `makecode-csp` prepended. This quirk is handled by using raw anchors instead `<a href="">...</a>`. Using ``<Link>`` will work also but the styles for `<a>` aren't inherited.

- [x] Change relative links from markdown format to `<a>`.

Re: https://github.com/microsoft/pxt/issues/8240