### PR TITLE
Unit 6 Relative link fixes and missing links

### DIFF
--- a/content/unit-6/day-11/binary-calculator-activity.md
+++ b/content/unit-6/day-11/binary-calculator-activity.md
@@ -10,11 +10,11 @@ Another option for teaching binary conversion is for students to create a binary
 
 This PowerPoint takes students through the steps for how to create a binary calculator. 
 
-[Optional Lesson on Binary Calculator]()
+[Optional Lesson on Binary Calculator](https://1drv.ms/w/s!AqsgsTyHBmRBj3LmCqu2IG8dFu8P?e=Y0KR5e)
 
 This is a template to use for the binary calculator. 
 
-[Binary Calculator Template]()
+[Binary Calculator Template](https://1drv.ms/w/s!AqsgsTyHBmRBj28lM0X0SX7t8U-2?e=TatP2n)
 
 ## If you plan to use it, before class
 

--- a/content/unit-6/day-11/binary-number-system.md
+++ b/content/unit-6/day-11/binary-number-system.md
@@ -8,12 +8,12 @@ order: 0
 
 ### Materials
 
-* [Day 11 PowerPoint deck]()
-* [How exactly does binary code work? - José Américo N L F de Freitas]()
-* [Binary Numbers Game]()
-* [Random.org]()
-* [Binary Homework]()
-* [Optional: Binary Calculator Activity]()
+* [Day 11 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj3GpS7gcjU2BsWlU?e=McCJbS)
+* [How exactly does binary code work? - José Américo N L F de Freitas](https://youtu.be/wgbV6DLVezo)
+* [Binary Numbers Game](https://games.penjee.com/binary-numbers-game/)
+* [Random.org](https://www.random.org/)
+* <a href="/unit-6/day-11/binary-homework">Binary Homewor</a>
+* <a href="/unit-6/day-11/binary-calculator-activity">Optional: Binary Calculator Activity</a>
 
 ### Instructional Activities and Classroom Assessments
 
@@ -26,24 +26,24 @@ order: 0
 
 ### Learning Objectives 
 
-* [DAT-1.A]() Explain how data can be represented using bits.
-* [DAT-1.C]() For binary numbers
+* [DAT-1.A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Explain how data can be represented using bits.
+* [DAT-1.C](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=55) For binary numbers
 Calculate the binary (base 2) equivalent of a positive integer (base 10) and vice versa.
 Compare and order binary numbers.
 
 ### Essential Knowledge
 
-* [DAT-1.A.1]() Data values can be stored in variables, lists of items, or standalone constants and can be passed as input to (or output from) procedures.
-* [DAT-1.A.2]() Computing devices represent data digitally, meaning that they lowest-level components of any value are bits. 
-* [DAT-1.A.3]() Bit is shorthand for binary digit and is either 0 or 1.
-* [DAT-1.A.4]() A byte is 8 bits.
-* [DAT-1.A.5]() Abstraction is the process of reducing complexity by focusing on the main idea. By hiding details irrelevant to the question at hand and bringing together related and useful details, abstraction reduces complexity and allows one to focus on the idea. 
-* [DAT-1.A.6]() Bits are grouped to represent abstractions. These abstractions include, but are not limited to, numbers, characters, and color.
-* [DAT-1.C.1]() Number bases, including binary and decimal, are used to represent data.
-* [DAT-1.C.2]() Binary (base 2) uses only combinations of the digits zero and one.
-* [DAT-1.C.3]() Decimal (base 10) uses only combinations of the digits 0-9.
-* [DAT-1.C.4]90 As with decimal, a digit's position in the library sequence determines its numeric value. The numeric value is equal to the bit's value (0 or 1) multiplied by the place value of its position.
-* [DAT-1.C.5]() The place value of each position is determined by the base raised to the power of the position. Positions are numbered starting at the rightmost position with 0 and increasing by 1 for each subsequent position to the left.
+* [DAT-1.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Data values can be stored in variables, lists of items, or standalone constants and can be passed as input to (or output from) procedures.
+* [DAT-1.A.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Computing devices represent data digitally, meaning that they lowest-level components of any value are bits. 
+* [DAT-1.A.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Bit is shorthand for binary digit and is either 0 or 1.
+* [DAT-1.A.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) A byte is 8 bits.
+* [DAT-1.A.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Abstraction is the process of reducing complexity by focusing on the main idea. By hiding details irrelevant to the question at hand and bringing together related and useful details, abstraction reduces complexity and allows one to focus on the idea. 
+* [DAT-1.A.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Bits are grouped to represent abstractions. These abstractions include, but are not limited to, numbers, characters, and color.
+* [DAT-1.C.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=55) Number bases, including binary and decimal, are used to represent data.
+* [DAT-1.C.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=55) Binary (base 2) uses only combinations of the digits zero and one.
+* [DAT-1.C.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=55) Decimal (base 10) uses only combinations of the digits 0-9.
+* [DAT-1.C.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=55) As with decimal, a digit's position in the library sequence determines its numeric value. The numeric value is equal to the bit's value (0 or 1) multiplied by the place value of its position.
+* [DAT-1.C.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=55) The place value of each position is determined by the base raised to the power of the position. Positions are numbered starting at the rightmost position with 0 and increasing by 1 for each subsequent position to the left.
 
 ## Details 
 
@@ -86,4 +86,4 @@ Compare and order binary numbers.
 
 ### 8. Optional
 
-* [Optional: Binary Calculator Activity]()
+* <a href="/unit-6/day-11/binary-calculator-activity">Optional: Binary Calculator Activity</a>

--- a/content/unit-6/day-12/encoding-ascii-utf-8.md
+++ b/content/unit-6/day-12/encoding-ascii-utf-8.md
@@ -8,12 +8,12 @@ order: 0
 
 ### Materials
 
-* [Day 12 PowerPoint deck]()
-* [ASCII secret message document]()
-* [ASCII and Unicode Character Sets]()
-* [ASCII Chart Handout]()
-* [ASCII Homework Handout]()
-* [ASCII Homework Handout]() in Word
+* [Day 12 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj3MJMZvNbkfBMxlj?e=fsbU9n)
+* [ASCII secret message document](https://1drv.ms/w/s!AqsgsTyHBmRBkF6oZc8YmFrxELek?e=V2hne6)
+* [ASCII and Unicode Character Sets](https://youtu.be/I-pQH_krD0M)
+* <a href="/unit-6/day-12/ascii-chart">ASCII Chart Handout</a>
+* <a href="/unit-6/day-11/binary-homework">ASCII Homework Handout</a>
+* [ASCII Homework Handout](https://1drv.ms/w/s!AqsgsTyHBmRBkGenx4jxCGR78j_P?e=ljb56P) in Word
 
 ### Instructional Activities and Classroom Assessments
 
@@ -26,15 +26,15 @@ order: 0
 
 ### Learning Objectives
 
-* [DAT 1-A]() Explain how data can be represented using bits.
+* [DAT 1-A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Explain how data can be represented using bits.
 
 ### Essential Knowledge
 
 * DAT-1.A.1
 * DAT-1.A.2
 * DAT-1.A.5
-* [DAT-1.A.6]() Bits are grouped to represent abstractions. These abstractions include, but are not limited to, numbers, characters, and color.
-* [DAT-1.A.7]() The same sequence of bits may represent different types of data in different contexts.
+* [DAT-1.A.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Bits are grouped to represent abstractions. These abstractions include, but are not limited to, numbers, characters, and color.
+* [DAT-1.A.7](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) The same sequence of bits may represent different types of data in different contexts.
 
 ## Details
 

--- a/content/unit-6/day-13/analog-data.md
+++ b/content/unit-6/day-13/analog-data.md
@@ -8,10 +8,10 @@ order: 0
 
 ### Materials
 
-* [Day 13 PowerPoint deck]()
-* [Digital Audio]()
-* [TwistedWave]()
-* [Royalty Free Music]()
+* [Day 13 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj3WcHol6VyiivWqB?e=K2DUmG)
+* [Digital Audio](https://youtu.be/JyUagzvGq7Q)
+* [TwistedWave](https://twistedwave.com/online)
+* [Royalty Free Music](https://www.royaltyfree-music.com/free-music-download)
 
 ### Instructional Activities and Classroom Assessments
 
@@ -24,15 +24,15 @@ order: 0
 
 ### Learning Objectives
 
-* [DAT 1-A]() Explain how data can be represented using bits.
+* [DAT 1-A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Explain how data can be represented using bits.
 
 ### Essential Knowledge
 
-* [DAT-1.A.6]() Bits are grouped to represent abstractions. These abstractions include, but are not limited to, numbers, characters, and color.
-* [DAT-1.A.7]() The same sequence of bits may represent different types of data in different contexts.
-* [DAT-1.A.8]() Analog data have values that change smoothly, rather than in discrete intervals, over time. Some examples of analog data include pitch and volume of music, colors of a painting, or position of a sprinter during a race.
-* [DAT-1.A.9]() The use of digital data to approximate real-world analog data is an example of abstraction.
-* [DAT-1.A.10]() Analog data can be closely approximated digitally using a sampling technique, which means measuring values of the analog signal at regular intervals called samples. The samples are measured to figure out the exact bits required to store each sample.
+* [DAT-1.A.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Bits are grouped to represent abstractions. These abstractions include, but are not limited to, numbers, characters, and color.
+* [DAT-1.A.7](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) The same sequence of bits may represent different types of data in different contexts.
+* [DAT-1.A.8](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) Analog data have values that change smoothly, rather than in discrete intervals, over time. Some examples of analog data include pitch and volume of music, colors of a painting, or position of a sprinter during a race.
+* [DAT-1.A.9](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) The use of digital data to approximate real-world analog data is an example of abstraction.
+* [DAT-1.A.10](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) Analog data can be closely approximated digitally using a sampling technique, which means measuring values of the analog signal at regular intervals called samples. The samples are measured to figure out the exact bits required to store each sample.
 
 ## Details
 

--- a/content/unit-6/day-14/base63-url-shorteners.md
+++ b/content/unit-6/day-14/base63-url-shorteners.md
@@ -83,4 +83,4 @@ Solution:
 
 **123456789089898** is represented as : **z3wBXxG2**.  
 
-Students will visit [Binary Challenge]()
+Students will visit [Binary Challenge](http://bit.ly/z3wBXxG2)

--- a/content/unit-6/day-14/hexadecimal-in-makecode.md
+++ b/content/unit-6/day-14/hexadecimal-in-makecode.md
@@ -10,7 +10,7 @@ Find your favorite colors using the Canva Color Wheel. Record the hex-codes of t
 
 As you know from creating your sprites, MakeCode Arcade has a palette of 16 colors - 15 colors and transparent. What if you could add your favorite color to the palette?
 
-1. Go to the [MakeCode Color Palette document]().
+1. Go to the [MakeCode Color Palette document](https://1drv.ms/w/s!AqsgsTyHBmRBkGjGeXdpq7UoOazc?e=NgS4cw).
 
 2. Replace two (or more) of the colors with your favorite complementary colors from the Canva color wheel. Make sure there are no extra spaces before or after the # (pound sign) or " (quotes).
 

--- a/content/unit-6/day-14/hexadecimal.md
+++ b/content/unit-6/day-14/hexadecimal.md
@@ -8,13 +8,13 @@ order: 0
 
 ### Materials
 
-* [Day 14 PowerPoint deck]()
-* [Hexadecimal]()
-* [Decimal to Hexadecimal]() worksheet
-* [Denary to Hexadecimal via Binary]() worksheet
-* [Base 62 and URL Shorteners]()
-* [Hexadecimal in MakeCode]()
-* [Extra Practice: Hexadecimal to Binary]()
+* [Day 14 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj3RQuJ3Yj3_jWG-c?e=UfrcZJ)
+* [Hexadecimal](https://youtu.be/UCgTEzcUolk)
+* <a href="/unit-6/day-14/decimal-hexadecimal">Decimal to Hexadecimal</a> worksheet
+* <a href="/unit-6/day-14/denary-hexadecimal-binary">Denary to Hexadecimal via Binary</a> worksheet
+* <a href="/unit-6/day-14/base63-url-shorteners">Base 62 and URL Shorteners</a>
+* <a href="/unit-6/day-14/hexadecimal-in-makecode">Hexadecimal in MakeCode</a>
+* <a href="/unit-6/day-14/extra-practice">Extra Practice: Hexadecimal to Binary</a>
 
 ### Instructional Activities and Classroom Assessments
 
@@ -28,13 +28,13 @@ order: 0
 
 ### Learning Objectives
 
-* [DAT 1-A]() Explain how data can be represented using bits.
+* [DAT 1-A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Explain how data can be represented using bits.
 
 ### Essential Knowledge
 
 * DAT-1.A.5
-* [DAT-1.A.6]() Bits are grouped to represent abstractions. These abstractions include, but are not limited to, numbers, characters, and color.
-* [DAT-1.A.7]() The same sequence of bits may represent different types of data in different contexts. 
+* [DAT-1.A.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Bits are grouped to represent abstractions. These abstractions include, but are not limited to, numbers, characters, and color.
+* [DAT-1.A.7](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) The same sequence of bits may represent different types of data in different contexts. 
 
 ## Details
 

--- a/content/unit-6/day-15/data-compression.md
+++ b/content/unit-6/day-15/data-compression.md
@@ -8,8 +8,8 @@ order: 0
 
 ### Materials
 
-* [Day 15 PowerPoint deck]()
-* [Extension - Reduce the file size of your Word documents]()
+* [Day 15 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj3Z1ZlaTtx42UZxV?e=U4rV2R)
+* <a href="/unit-6/day-15/reduce-file-size">Extension - Reduce the file size of your Word documents</a>
 
 
 ### Instructional Activities and Classroom Assessments
@@ -60,4 +60,4 @@ order: 0
 
 ### 5. Extension activity  
 
-* If you finish early, students can read [Reduce the file size of your Word documents - Word]().
+* If you finish early, students can read <a href="/unit-6/day-15/reduce-file-size">Extension - Reduce the file size of your Word documents</a>.

--- a/content/unit-6/day-16/how-computer-programmers-use-data.md
+++ b/content/unit-6/day-16/how-computer-programmers-use-data.md
@@ -8,10 +8,10 @@ order: 0
 
 ### Materials
 
-* [Day 16 PowerPoint slide]()
+* [Day 16 PowerPoint slide](https://1drv.ms/p/s!AqsgsTyHBmRBj3eCtsusvok74STG?e=FipbXw)
 * [MakeCode Arcade Precision Activities](/unit-6/day-16/makecode-arcade-precision-activities)
-* [MakeCode Arcade Precision Activities]() in Word
-* [Homework](/unit-6/day-16/homework)
+* [MakeCode Arcade Precision Activities](https://1drv.ms/w/s!AqsgsTyHBmRBkGnF1PQSYkcccefi?e=mlYPP2) in Word
+* <a href="/unit-6/day-16/homework">Homework</a>
 
 ### Instructional Activities and Classroom Assessments
 

--- a/content/unit-6/day-17/impact-of-computing.md
+++ b/content/unit-6/day-17/impact-of-computing.md
@@ -8,10 +8,10 @@ order: 0
 
 ### Materials
 
-* [Day 17 PowerPoint deck]()
-* [Impact of a Computing Innovation - Recurring Assignment]() (already handed out to students on Day 11 of Unit 1)
-* [Data in Computing Innovations]() handout
-* [Data in Computing Innovations]() handout in Word
+* [Day 17 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkBbwvnPkClIOUPx-?e=zzQsxV)
+* <a href="/unit-1/day-11/impact-computing-innovation">Impact of a Computing Innovation - Recurring Assignment</a> (already handed out to students on Day 11 of Unit 1)
+* <a href="/unit-6/day-17/data-in-computing-innovations">Data in Computing Innovations</a> handout
+* [Data in Computing Innovations](https://1drv.ms/w/s!AqsgsTyHBmRBkBeQdSsfkAHhFT2R?e=3F4PjH) handout in Word
 
 ### Instructional Activities and Classroom Assessments
 
@@ -21,26 +21,26 @@ order: 0
 
 ### Learning Objectives 
 
-* [IOC-1.A]() Explain how an effect of a computing innovation can be both beneficial and harmful.
-* [IOC-1.B]() Explain how a computing innovation can have an impact beyond its intended purpose.
-Computational Thinking Practice [5.C]() Describe the impact of a computing innovation.
+* [IOC-1.A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) Explain how an effect of a computing innovation can be both beneficial and harmful.
+* [IOC-1.B](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122) Explain how a computing innovation can have an impact beyond its intended purpose.
+Computational Thinking Practice [5.C](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=23) Describe the impact of a computing innovation.
 
 ### Essential Knowledge 
 
-* [IOC-1.A.1]() People create computing innovations.
-* [IOC-1.A.2]() The way people complete tasks often changes to incorporate new computing innovations.
-* [IOC-1.A.3]() Not every effect of a computing innovation is anticipated in advance.
-* [IOC-1.A.4]() A single effect can be viewed as both beneficial and harmful by different people, or even by the same person.
-* [IOC-1.A.5]() Advances in computing have generated and increased creativity in other fields, such as medicine, engineering, communications, and the arts.
-* [IOC-1.B.1]() Computing innovations can be used in ways that their creators had not originally intended:
+* [IOC-1.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) People create computing innovations.
+* [IOC-1.A.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) The way people complete tasks often changes to incorporate new computing innovations.
+* [IOC-1.A.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) Not every effect of a computing innovation is anticipated in advance.
+* [IOC-1.A.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) A single effect can be viewed as both beneficial and harmful by different people, or even by the same person.
+* [IOC-1.A.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=121) Advances in computing have generated and increased creativity in other fields, such as medicine, engineering, communications, and the arts.
+* [IOC-1.B.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122) Computing innovations can be used in ways that their creators had not originally intended:
     * The World Wide Web was originally intended for rapid and easy exchange of information within the scientific community.
     * Targeted advertising is used to help businesses, but it can be misused at both individual and aggregate levels.
     * Machine learning and data mining have enabled innovation in medicine, business, and science, but information discovered in this way has also been used to discriminate against groups of individuals.
-* [IOC-1.B.2]() Some of the ways computing innovations can be used may have a harmful impact on society, the economy, or culture.
-* [IOC-1.B.3]() Responsible programmers try to consider the unintended ways their computing innovations can be used and the potential beneficial and harmful effects of these new uses.
-* [IOC-1.B.4]() It is not possible for a programmer to consider all the ways a computing innovation can be used.
-* [IOC-1.B.5]() Computing innovations have often had unintended beneficial effects by leading to advances in other fields.
-* [IOC-1.B.6]() Rapid sharing of a program or running a program with a large number of users can result in significant impacts beyond the intended purpose or control of the programmer.
+* [IOC-1.B.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122) Some of the ways computing innovations can be used may have a harmful impact on society, the economy, or culture.
+* [IOC-1.B.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122) Responsible programmers try to consider the unintended ways their computing innovations can be used and the potential beneficial and harmful effects of these new uses.
+* [IOC-1.B.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122) It is not possible for a programmer to consider all the ways a computing innovation can be used.
+* [IOC-1.B.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122) Computing innovations have often had unintended beneficial effects by leading to advances in other fields.
+* [IOC-1.B.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=122) Rapid sharing of a program or running a program with a large number of users can result in significant impacts beyond the intended purpose or control of the programmer.
 
 ## Details
 

--- a/content/unit-6/day-2/what-is-data-science.md
+++ b/content/unit-6/day-2/what-is-data-science.md
@@ -8,16 +8,16 @@ order: 0
 
 ### Materials 
 
-* [Day 2 PowerPoint deck]()
+* [Day 2 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj2mWxLmeJYLj791G?e=YEbkxc)
 * <a href="/unit-6/day-2/data-research-project">Data Research Project</a>
-* [Data Research Project]() in Word 
+* [Data Research Project](https://1drv.ms/w/s!AqsgsTyHBmRBkGL6-99yrOBBnv29?e=nOeFGD) in Word 
 * <a href="/unit-6/day-2/data-science-process">Data Science Process Checklist</a>
-* [Data Science Process Checklist]() in Word 
+* [Data Science Process Checklist](https://1drv.ms/w/s!AqsgsTyHBmRBkGNXFKQarLJbzE_y?e=okY1qN) in Word 
 * <a href="/unit-6/day-2/data-research-brainstorm">Data Research Brainstorm</a>
-* [Data Research Brainstorm]() in Word 
+* [Data Research Brainstorm](https://1drv.ms/w/s!AqsgsTyHBmRBkGTwk1mpKqEKv04Y?e=nf7mja) in Word 
 * <a href="/unit-6/day-2/research-prompt-ideas">Research Prompt Ideas</a>
-* [Research Prompt Ideas]() in Word
-* [What is Data Science? | Great Learning]()
+* [Research Prompt Ideas](https://1drv.ms/w/s!AqsgsTyHBmRBkGXOGGABffQeJL-2?e=6eoQgq) in Word
+* [What is Data Science? | Great Learning](https://youtu.be/Nrfht_c3T7w)
 
 ### Instructional Activities and Classroom Assessments
 
@@ -28,17 +28,17 @@ order: 0
 
 ### Learning Objectives 
 
-* [DAT-2.A]() Describe what information can be extracted from data.
+* [DAT-2.A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Describe what information can be extracted from data.
 * DAT-2.C
 * DAT-2.D
 * DAT-2.E
 
 ### Essential Knowledge 
 
-* [DAT-2.A.1]() Information is the collection of facts and patterns extracted from data.
-* [DAT-2.A.2]() Data provide opportunities for identifying trends, make connections, and addressing problems.
-* [DAT-2-A.3]() Digitally processed data may show correlation between variables. A correlation found in data does not necessarily indicate that a causal relationship exists. Additional research is needed to understand the exact nature of the relationship.
-* [DAT-2.A.4]() Often, a single source does not contain the data needed to draw a conclusion. It may be necessary to combine data from a variety of sources to formulate a conclusion.
+* [DAT-2.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Information is the collection of facts and patterns extracted from data.
+* [DAT-2.A.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Data provide opportunities for identifying trends, make connections, and addressing problems.
+* [DAT-2-A.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Digitally processed data may show correlation between variables. A correlation found in data does not necessarily indicate that a causal relationship exists. Additional research is needed to understand the exact nature of the relationship.
+* [DAT-2.A.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Often, a single source does not contain the data needed to draw a conclusion. It may be necessary to combine data from a variety of sources to formulate a conclusion.
 * DAT-2.C.1
 * DAT-2.C.2
 * DAT-2.C.3

--- a/content/unit-6/day-3/data-collection.md
+++ b/content/unit-6/day-3/data-collection.md
@@ -8,12 +8,12 @@ order: 0
 
 ### Materials
 
-* [Day 3 PowerPoint deck]()
-* [Data Science Process Checklist]()
+* [Day 3 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj2sWbf6vlTKBzR7L?e=h730fI)
+* <a href="/unit-6/day-2/data-science-process">Data Science Process Checklist</a>
 * <a href="/unit-6/day-3/bias-in-surveys-activity">Bias in Surveys Activity</a>
 * <a href="/unit-6/day-3/examples-biased-surveys-questions">Examples of Biased Survey Questions</a>
 * <a href="/unit-6/day-3/survey-rubric">Survey Rubric</a>
-* [Survey Rubric]() in Word
+* [Survey Rubric](https://1drv.ms/w/s!AqsgsTyHBmRBj2dC_oU0uPaB3GZc?e=aj2XFX) in Word
 
 ### Instructional Activities and Classroom Assessments
 
@@ -27,17 +27,17 @@ order: 0
 
 ### Learning Objectives 
 
-* [DAT-2.A]() Describe what information can be extracted from data.
-* [DAT-2.C]() Identify the challenges associated with processing data.
+* [DAT-2.A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Describe what information can be extracted from data.
+* [DAT-2.C](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Identify the challenges associated with processing data.
 
 ### Essential Knowledge 
 
-* [DAT-2.A.1]() Information is the collection of facts and patterns extracted from data. 
-* [DAT-2.A.2]() Data provide opportunities for identifying trends, make connections, and addressing problems. 
-* [DAT-2-A.3]() Digitally processed data may show correlation between variables. A correlation found in data does not necessarily indicate that a causal relationship exists. Additional research is needed to understand the exact nature of the relationship. 
-* [DAT-2.A.4]() Often, a single source does not contain the data needed to draw a conclusion. It may be necessary to combine data from a variety of sources to formulate a conclusion.
+* [DAT-2.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Information is the collection of facts and patterns extracted from data. 
+* [DAT-2.A.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Data provide opportunities for identifying trends, make connections, and addressing problems. 
+* [DAT-2-A.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Digitally processed data may show correlation between variables. A correlation found in data does not necessarily indicate that a causal relationship exists. Additional research is needed to understand the exact nature of the relationship. 
+* [DAT-2.A.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Often, a single source does not contain the data needed to draw a conclusion. It may be necessary to combine data from a variety of sources to formulate a conclusion.
 * DAT-2.C.1
-* [DAT-2.C.5]() Problems of bias are often created by the type or source of data being collected. Bias is not eliminated by simply collecting more data.
+* [DAT-2.C.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Problems of bias are often created by the type or source of data being collected. Bias is not eliminated by simply collecting more data.
 
 ### 0. Before class  
 

--- a/content/unit-6/day-4/data-ethics-survey-creation.md
+++ b/content/unit-6/day-4/data-ethics-survey-creation.md
@@ -8,10 +8,10 @@ order: 0
 
 ### Materials
 
-* [Day 4 PowerPoint deck]()
-* [Survey Rubric]()
-* [Data Science Process Checklist]()
-* [Microsoft Forms]()
+* [Day 4 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj2yvygylh2ZBo-46?e=FcWbny)
+* <a href="/unit-6/day-3/survey-rubric">Survey Rubric</a>
+* <a href="/unit-6/day-2/data-science-process">Data Science Process Checklist</a>
+* [Microsoft Forms](https://forms.office.com/)
 
 ### Instructional Activities and Classroom Assessments
 
@@ -24,17 +24,17 @@ order: 0
 
 ### Learning Objectives
 
-* [DAT-2.A]() Describe what information can be extracted from data.
+* [DAT-2.A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Describe what information can be extracted from data.
 * DAT-2.D
 * IOC-1.F
 * IOC-2.A
 
 ### Essential Knowledge
 
-* [DAT-2.A.1]() Information is the collection of facts and patterns extracted from data.
-* [DAT-2.A.2]() Data provide opportunities for identifying trends, make connections, and addressing problems. 
-* [DAT-2-A.3]() Digitally processed data may show correlation between variables. A correlation found in data does not necessarily indicate that a causal relationship exists. Additional research is needed to understand the exact nature of the relationship. 
-* [DAT-2.A.4]() Often, a single source does not contain the data needed to draw a conclusion. It may be necessary to combine data from a variety of sources to formulate a conclusion.
+* [DAT-2.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Information is the collection of facts and patterns extracted from data.
+* [DAT-2.A.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Data provide opportunities for identifying trends, make connections, and addressing problems. 
+* [DAT-2-A.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Digitally processed data may show correlation between variables. A correlation found in data does not necessarily indicate that a causal relationship exists. Additional research is needed to understand the exact nature of the relationship. 
+* [DAT-2.A.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=58) Often, a single source does not contain the data needed to draw a conclusion. It may be necessary to combine data from a variety of sources to formulate a conclusion.
 * DAT-2.D.1
 * IOC-1.F.9
 * IOC-2.A.1

--- a/content/unit-6/day-5/testing-sharing-your-survey.md
+++ b/content/unit-6/day-5/testing-sharing-your-survey.md
@@ -8,10 +8,10 @@ order: 0
 
 ### Materials
 
-* [Day 5 PowerPoint deck]()
-* [Survey Rubric]()
-* [Survey Link & QR Code]()
-* [Data Science Process Checklist]()
+* [Day 5 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj20JuYO0mPI6jw1j?e=4fPtct)
+* <a href="/unit-6/day-3/survey-rubric">Survey Rubric</a>
+* <a href="/unit-6/day-5/survey-link-qr-code">Survey Link & QR Code</a>
+* <a href="/unit-6/day-2/data-science-process">Data Science Process Checklist</a>
 
 ### Instructional Activities and Classroom Assessments
 
@@ -24,22 +24,22 @@ order: 0
 ### Learning Objectives 
 
 * DAT-2.A
-* [DAT-2.C]() Identify the challenges associated with processing data.
-* [DAT-2.D]() Extract information from data using a program.
+* [DAT-2.C](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Identify the challenges associated with processing data.
+* [DAT-2.D](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Extract information from data using a program.
 
 ### Essential Knowledge
 
 * DAT-2.A.1
-* [DAT-2.C.1]() The ability to process data depends on the capabilities of the users and their tools.
-* [DAT-2.D.1]() Programs can be used to process data to acquire information.
+* [DAT-2.C.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) The ability to process data depends on the capabilities of the users and their tools.
+* [DAT-2.D.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Programs can be used to process data to acquire information.
 
 ## Details
 
 ### 1. Create share link and QR code (5 minutes) 
 
-Show students how to generate share link and QR code link.
-Have students create both.
-Ask students to add their link and QR code to the Survey Link and QR Code page in their section of the notebook.
+* Show students how to generate share link and QR code link.
+* Have students create both.
+* Ask students to add their link and QR code to the <a href="/unit-6/day-5/survey-link-qr-code">Survey Link & QR Code</a> page in their section of the notebook.
 
 ### 2. Test survey (15 minutes) 
 

--- a/content/unit-6/day-6/data-cleansing-visualization.md
+++ b/content/unit-6/day-6/data-cleansing-visualization.md
@@ -8,14 +8,14 @@ order: 0
 
 ### Materials
 
-* [Day 6 PowerPoint deck]()
-* [For Teacher - Excel Information]()
-* [Survey Cleansing & Chart Help]()
-* [Sample Survey Responses]()
-* [Data Science Process Reflection]()
-* [Data Science Process Reflection]() in Word
-* [Flash Fill]()
-* [Available Chart Types in Office]()
+* [Day 6 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj256f7nOox9yxHvP?e=ZZULsa)
+* <a href="/unit-6/day-6/for-teacher-excel-information">For Teacher - Excel Information</a>
+* <a href="/unit-6/day-6/survey-cleansing-chart-help">Survey Cleansing & Chart Help</a>
+* <a href="/unit-6/day-6/sample-survey-responses">Sample Survey Responses</a>
+* <a href="/unit-6/day-6/data-science-process-reflection">Data Science Process Reflection</a>
+* [Data Science Process Reflection](https://1drv.ms/w/s!AqsgsTyHBmRBkGbcX_VHyQyKrWGX?e=c09BGu) in Word
+* [Flash Fill](https://support.microsoft.com/en-us/office/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464)
+* [Available Chart Types in Office](https://support.microsoft.com/en-us/office/available-chart-types-in-office-a6187218-807e-4103-9e0a-27cdb19afb90)
 
 ### Instructional Activities and Classroom Assessments
 
@@ -26,35 +26,35 @@ order: 0
 
 ### Learning Objectives 
 
-* [DAT-2.C]() Identify the challenges associated with processing data.
-* [DAT-2.D]() Extract information from data using a program.
-* [DAT-2.E]() Explain how programs can be used to gain insight and knowledge from data.
+* [DAT-2.C](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Identify the challenges associated with processing data.
+* [DAT-2.D](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Extract information from data using a program.
+* [DAT-2.E](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Explain how programs can be used to gain insight and knowledge from data.
 
 ### Essential Knowledge 
 
-* [DAT-2.C.1]() The ability to process data depends on the capabilities of the users and their tools.
-* [DAT-2.C.2]() Data sets pose challenges regardless of size, such as:
+* [DAT-2.C.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) The ability to process data depends on the capabilities of the users and their tools.
+* [DAT-2.C.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Data sets pose challenges regardless of size, such as:
     * The need to clean data
     * Incomplete data
     * Invalid data
     * The need to combine data sources
-* [DAT-2.C.3]() Depending on how data were collected, they may not be uniform. For example, if users enter data into an open field, the way they choose to abbreviate, spell, or capitalize something may vary from user to user.
-* [DAT-2.C.4]() Cleaning data is a process that makes the data uniform without changing their meaning (e.g., replacing all equivalent abbreviations, spellings, and capitalizations with the same word).
-* [DAT-2.D.1]() Programs can be used to process data to acquire information.
-* [DAT-2.D.2]() Tables, diagrams, text, and other visual tools can be used to communicate insight and knowledge gained from data.
-* [DAT-2.D.3]() Search tools are useful for efficiently finding information.
-* [DAT-2.D.4]() Data filtering systems are important tools for finding information and recognizing patterns in data.
-* [DAT-2.D.5]() Programs such as spreadsheets help efficiently organize and find trends in information
-* [DAT-2.D.6]() Some processes that can be used to extract or modify information from data include the following:
+* [DAT-2.C.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Depending on how data were collected, they may not be uniform. For example, if users enter data into an open field, the way they choose to abbreviate, spell, or capitalize something may vary from user to user.
+* [DAT-2.C.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Cleaning data is a process that makes the data uniform without changing their meaning (e.g., replacing all equivalent abbreviations, spellings, and capitalizations with the same word).
+* [DAT-2.D.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Programs can be used to process data to acquire information.
+* [DAT-2.D.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Tables, diagrams, text, and other visual tools can be used to communicate insight and knowledge gained from data.
+* [DAT-2.D.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Search tools are useful for efficiently finding information.
+* [DAT-2.D.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Data filtering systems are important tools for finding information and recognizing patterns in data.
+* [DAT-2.D.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Programs such as spreadsheets help efficiently organize and find trends in information
+* [DAT-2.D.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Some processes that can be used to extract or modify information from data include the following:
     * Transforming every element of a data set, such as doubling every element in a list, or adding a parent's email to every student record.
     * Filtering a data set, such as keeping only the positive numbers from a list, or keeping only students who signed up for band from a record of all the students.
     * Combining or comparing data in some way, such as adding up a list of numbers, or finding the student who has the highest GPA.
     * Visualizing a data set through a chart, graph, or other visual representation.
-* [DAT-2.E.1]() Programs used in an iterative and interactive way when processing information to allow users to gain insight and knowledge about data.
-* [DAT-2.E.2]() Programmers can use programs to filter and clean digital data, thereby gaining insight and knowledge.
-* [DAT-2.E.3]() Combining data sources, clustering data, and classifying data are parts of the process of using programs to gain insight and knowledge from data.
-* [DAT-2.E.4]() Insight and knowledge can be obtained from translating and transforming digitally represented information.
-* [DAT-2.E.5]() Patterns can emerge when data are transformed using programs.
+* [DAT-2.E.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Programs used in an iterative and interactive way when processing information to allow users to gain insight and knowledge about data.
+* [DAT-2.E.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Programmers can use programs to filter and clean digital data, thereby gaining insight and knowledge.
+* [DAT-2.E.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Combining data sources, clustering data, and classifying data are parts of the process of using programs to gain insight and knowledge from data.
+* [DAT-2.E.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Insight and knowledge can be obtained from translating and transforming digitally represented information.
+* [DAT-2.E.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Patterns can emerge when data are transformed using programs.
 
 ## Details
 
@@ -62,8 +62,8 @@ order: 0
 
 * Decide how much time you will give students to collect responses to their surveys. 
 * Enter the amount of time you will give students to collect responses on the second slide of the PowerPoint.
-* Watch the video on the [For Teacher - Analyzing Data in Excel]() page.
-* Review resources on [Survey Chart Help]() page.
+* Watch the video on the <a href="/unit-6/day-6/for-teacher-excel-information">For Teacher - Excel Information</a> page.
+* Review resources on <a href="/unit-6/day-6/survey-cleansing-chart-help">Survey Cleansing & Chart Help</a> page.
 
 ### 1. Next steps (5 minutes)
 
@@ -78,14 +78,14 @@ order: 0
 * Discuss the challenges with processing data.
 * Discuss what cleansing data is.
 * Play the Flash Fill and Auto Fill videos on the website.
-* Encourage students to practice cleansing data with the Excel spreadsheet on the [Sample Survey Responses]() page.
+* Encourage students to practice cleansing data with the Excel spreadsheet on the <a href="/unit-6/day-6/sample-survey-responses">Sample Survey Responses</a> page.
 
 ### 3. Chart types (10 minutes)
 
 * Explore Chart types in Office webpage.
 * Discuss the types of charts students learned about on the webpage.
-* Encourage students to practice creating charts with the Excel spreadsheet on the [Sample Survey Responses]() page.
+* Encourage students to practice creating charts with the Excel spreadsheet on the <a href="/unit-6/day-6/sample-survey-responses">Sample Survey Responses</a> page.
 
 ### 4. Homework 
 
-* Reflect on what they have learned working through the data science process by completing the [Data Science Process Reflection]() page.
+* Reflect on what they have learned working through the data science process by completing the <a href="/unit-6/day-6/data-science-process-reflection">Data Science Process Reflection</a> page.

--- a/content/unit-6/day-6/for-teacher-excel-information.md
+++ b/content/unit-6/day-6/for-teacher-excel-information.md
@@ -8,7 +8,7 @@ order: 1
 
 https://youtu.be/lWgdVemOQaA
 
-You can find the raw data that you and your students will use here - [Sample Survey Responses]() 
+You can find the raw data that you and your students will use here - <a href="/unit-6/day-6/sample-survey-responses">Sample Survey Responses</a> 
 
 The Excel spreadsheet below has been cleaned and has a few charts you can show students:
 

--- a/content/unit-6/day-7-10/infograpic-project.md
+++ b/content/unit-6/day-7-10/infograpic-project.md
@@ -8,16 +8,16 @@ order: 0
 
 ### Materials
 
-* [Day 7 - 10 PowerPoint deck]()
-* [Data Science Process Checklist]()
-* [Infographic Tips]()
-* [genial.ly]()
-* [Infographic Rubric]()
-* [Infographic Rubric]() in Word
+* [Day 7 - 10 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBj3AfG-XjEfWUsXa3?e=zNc7zL)
+* <a href="/unit-6/day-2/data-science-process">Data Science Process Checklist</a>
+* <a href="/unit-6/day-7-10/infograpic-tips">Infographic Tips</a>
+* [genial.ly](https://www.genial.ly/)
+* <a href="/unit-6/day-7-10/infograpic-rubric">Infographic Rubric</a>
+* [Infographic Rubric](https://1drv.ms/w/s!AqsgsTyHBmRBj2a4sRWKHaCSJEKy?e=FwAase) in Word
 
 ### Instructional Activities and Classroom Assessments
 
-* Day 7
+#### Day 7
 
 1. Data Science Project Plan Discussion (15 minutes) 
 2. Download the Data (5 minutes)
@@ -25,13 +25,13 @@ order: 0
 4. Optional: Data Visualization
 5. Homework
 
-* Day 8
+#### Day 8
 
 1. Workday (30 minutes)
 2. Infographic Tips (15 minutes)
 3. Homework
 
-* Day 9
+#### Day 9
 
 1. Workday (35 minutes)
 2. Peer Review (10 minutes)
@@ -43,35 +43,35 @@ order: 0
 
 ### Learning Objectives 
 
-* [DAT-2.C]() Identify the challenges associated with processing data.
-* [DAT-2.D]() Extract information from data using a program.
-* [DAT-2.E]() Explain how programs can be used to gain insight and knowledge from data.
+* [DAT-2.C](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Identify the challenges associated with processing data.
+* [DAT-2.D](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Extract information from data using a program.
+* [DAT-2.E](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Explain how programs can be used to gain insight and knowledge from data.
 
 ### Essential Knowledge
 
-* [DAT-2.C.1]() The ability to process data depends on the capabilities of the users and their tools.
-* [DAT-2.C.2]() Data sets pose challenges regardless of size, such as:
+* [DAT-2.C.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) The ability to process data depends on the capabilities of the users and their tools.
+* [DAT-2.C.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Data sets pose challenges regardless of size, such as:
     * The need to clean data
     * Incomplete data
     * Invalid data
     * The need to combine data sources
-* [DAT-2.C.3]() Depending on how data were collected, they may not be uniform. For example, if users enter data into an open field, the way they choose to abbreviate, spell, or capitalize something may vary from user to user.
+* [DAT-2.C.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=59) Depending on how data were collected, they may not be uniform. For example, if users enter data into an open field, the way they choose to abbreviate, spell, or capitalize something may vary from user to user.
 * DAT-2.C.4
-* [DAT-2.D.1]() Programs can be used to process data to acquire information.
-* [DAT-2.D.2]() Tables, diagrams, text, and other visual tools can be used to communicate insight and knowledge gained from data.
-* [DAT-2.D.3]() Search tools are useful for efficiently finding information.
-* [DAT-2.D.4]() Data filtering systems are important tools for finding information and recognizing patterns in data
-* [DAT-2.D.5]() Programs such as spreadsheets help efficiently organize and find trends in information.
-* [DAT-2.D.6]() Some processes that can be used to extract or modify information from data include the following:
+* [DAT-2.D.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Programs can be used to process data to acquire information.
+* [DAT-2.D.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Tables, diagrams, text, and other visual tools can be used to communicate insight and knowledge gained from data.
+* [DAT-2.D.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Search tools are useful for efficiently finding information.
+* [DAT-2.D.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Data filtering systems are important tools for finding information and recognizing patterns in data
+* [DAT-2.D.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=61) Programs such as spreadsheets help efficiently organize and find trends in information.
+* [DAT-2.D.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Some processes that can be used to extract or modify information from data include the following:
     * Transforming every element of a data set, such as doubling every element in a list, or adding a parent's email to every student record.
     * Filtering a data set, such as keeping only the positive numbers from a list, or keeping only students who signed up for band from a record of all the students.
     * Combining or comparing data in some way, such as adding up a list of numbers, or finding the student who has the highest GPA.
     * Visualizing a data set through a chart, graph, or other visual representation.
-* [DAT-2.E.1]() Programs used in an iterative and interactive way when processing information to allow users to gain insight and knowledge about data.
-* [DAT-2.E.2]() Programmers can use programs to filter and clean digital data, thereby gaining insight and knowledge.
-* [DAT-2.E.3])() Combining data sources, clustering data, and classifying data are parts of the process of using programs to gain insight and knowledge from data.
-* [DAT-2.E.4]() Insight and knowledge can be obtained from translating and transforming digitally represented information.
-* [DAT-2.E.5]() Patterns can emerge when data are transformed using programs.
+* [DAT-2.E.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Programs used in an iterative and interactive way when processing information to allow users to gain insight and knowledge about data.
+* [DAT-2.E.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Programmers can use programs to filter and clean digital data, thereby gaining insight and knowledge.
+* [DAT-2.E.3](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Combining data sources, clustering data, and classifying data are parts of the process of using programs to gain insight and knowledge from data.
+* [DAT-2.E.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Insight and knowledge can be obtained from translating and transforming digitally represented information.
+* [DAT-2.E.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=62) Patterns can emerge when data are transformed using programs.
 
 ## Details
 

--- a/content/unit-6/extension-activity/create-emg-sensor-activity.md
+++ b/content/unit-6/extension-activity/create-emg-sensor-activity.md
@@ -8,8 +8,8 @@ order: 0
 
 ### Materials
 
-* [EMG PowerPoint]()
-* [Science Experiments 05 EMG Sensor]()
+* [EMG PowerPoint](https://1drv.ms/p/s!AqsgsTyHBmRBj2iKCvNUOb1vOMZ8?e=7mQQze)
+* [Science Experiments 05 EMG Sensor](https://youtu.be/vxlPQZIwYRc)
 * Micro:bits
 * Alligator clips
 * Aluminum foil
@@ -23,13 +23,13 @@ order: 0
 
 ### Learning Objectives
 
-* [DAT 1-A]() Explain how data can be represented using bits.
+* [DAT 1-A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=53) Explain how data can be represented using bits.
 
 ### Essential Knowledge
 
-* [DAT-1.A.7]() The same sequence of bits may represent different types of data in different contexts.
-* [DAT-1.A.8]() Analog data have values that change smoothly, rather than in discrete intervals, over time. Some examples of analog data include pitch and volume of music, colors of a painting, or position of a sprinter during a race.
-* [DAT-1.A.9]() The use of digital data to approximate real-world analog data is an example of abstraction.
+* [DAT-1.A.7](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) The same sequence of bits may represent different types of data in different contexts.
+* [DAT-1.A.8](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) Analog data have values that change smoothly, rather than in discrete intervals, over time. Some examples of analog data include pitch and volume of music, colors of a painting, or position of a sprinter during a race.
+* [DAT-1.A.9](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=54) The use of digital data to approximate real-world analog data is an example of abstraction.
 
 ## Details
 


### PR DESCRIPTION
Relative links from markdown will get a duplicated path prefix `makecode-csp` prepended. This quirk is handled by using raw anchors instead `<a href="">...</a>`. Using ``<Link>`` will work also but the styles for `<a>` aren't inherited.

- [x] Change relative links from markdown format to `<a>`.
- [x] Check for other missing links too and fill them in.

Re: #43