### PR TITLE
Remaining relative link fixes and missing links

### DIFF
--- a/content/unit-3/day-12/conditional-statements.md
+++ b/content/unit-3/day-12/conditional-statements.md
@@ -38,8 +38,8 @@ order: 0
 * [AAP-1.A.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=70) A variable is an abstraction inside a program that can hold a value. Each variable has associated data storage that represents one value at a time, but that value can be a list or other collection that in turn contains multiple values.
 * [AAP-1.A.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=70) Using meaningful variable names helps with the readability of program code and understanding of what values are represented by the variables.
 * AAP-2.G.1 Selection determines which parts of an algorithm are executed based on a condition being true or false.  
-* [AAP-2.H.1]() Conditional statements, or “if-statements,” affect the sequential flow of control by executing different statements based on the value of a Boolean expression.
-* [AAP-2.H.2]() The exam reference sheet provides
+* [AAP-2.H.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=80) Conditional statements, or “if-statements,” affect the sequential flow of control by executing different statements based on the value of a Boolean expression.
+* [AAP-2.H.2](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=80) The exam reference sheet provides
     * Text: IF(condition) {    &lt;block of statements&gt; }
     * Block: IF condition block of statements in which the code in block of statements is executed if the Boolean expression condition evaluates to true; no action is taken if condition evaluates to false.
 

--- a/content/unit-3/day-19-22/culminating-project.md
+++ b/content/unit-3/day-19-22/culminating-project.md
@@ -8,7 +8,7 @@ order: 0
 
 ### Materials
 
-* [Days 19-22 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFyXQ-ooj03xM0wA/e=jYCzol)
+* [Days 19-22 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkFyXQ-ooj03xM0wA?e=jYCzol)
 * <a href="/unit-3/day-19-22/projects-requirements-responses">Project Requirements & Responses</a> handout
 * [Project Requirements & Responses](https://1drv.ms/w/s!AqsgsTyHBmRBkEqcSqfKEXwpxWhd?e=Yf1WQk) handout in Word
 * <a href="(/unit-3/day-19-22/project-rubric">Project Rubric</a> handout
@@ -156,4 +156,4 @@ The project is a review of the essential knowledge skills covered in this unit.
 
 #### Respond to prompts and turn in project (40 minutes) 
 
-* Task students with completing the written responses to the prompts found on the [Project Requirements & Responses]() page. 
+* Task students with completing the written responses to the prompts found on the <a href="/unit-3/day-19-22/projects-requirements-responses">Project Requirements & Responses</a> page. 

--- a/content/unit-4/day-11/legal-ethical-concerns.md
+++ b/content/unit-4/day-11/legal-ethical-concerns.md
@@ -27,7 +27,7 @@ order: 0
 
 ### Learning Objectives
 
-* Computational Thinking Practice [5.E](). 
+* Computational Thinking Practice [5.E](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=23). 
 * [IOC-1.F](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf#page=126) Explain how the use of computing can raise legal and ethical concerns.
 
 ### Essential Knowledge 

--- a/content/unit-4/day-16/impact-of-computing.md
+++ b/content/unit-4/day-16/impact-of-computing.md
@@ -9,7 +9,7 @@ order: 0
 ### Materials
 
 * [Day 16 PowerPoint deck](https://1drv.ms/w/s!AqsgsTyHBmRBkBW3l0eAIhPGXD7D?e=jayMpP)
-* [Impact of a Computing Innovation - Recurring Assignment]() (already handed out to students on Day 11 of Unit 1)
+* <a href="/unit-1/day-11/impact-computing-innovation">Impact of a Computing Innovation - Recurring Assignment</a> (already handed out to students on Day 11 of Unit 1)
 * <a href="/unit-4/day-16/privacy-and-security">Privacy & Security in Computing Innovations</a>
 * [Privacy & Security in Computing Innovations](https://1drv.ms/w/s!AqsgsTyHBmRBkCQ-aRBWwE6GWU4i?e=kjEFL8) in Word
  

--- a/content/unit-5/day-15/string-arrays.md
+++ b/content/unit-5/day-15/string-arrays.md
@@ -56,7 +56,7 @@ order: 0
 * [AAP-1.D.4](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=73) Developing a data abstraction to implement in a program can result in a program that is easier to develop and maintain.
 * [AAP-1.D.5](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=73) Data abstractions often contain different types of elements.
 * [AAP-1.D.6](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=73) The use of lists allows multiple related items to be treated as a single value. Lists are referred to by different names, such as array, depending on the programming language.
-* [AAP-2.N.1]() The exam reference sheet provides basic operations on lists, including:<br/>
+* [AAP-2.N.1](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=87) The exam reference sheet provides basic operations on lists, including:<br/>
 § accessing an element by index Text: aList[i] Block: aList i accesses the element of aList at index i. The first element of aList is at index 1 and is accessed using the notation  aList[1].<br/>
 § assigning a value of an element of a list to a variable Text: X ← aList [i] Block: X aList i assigns the value of aList[i] to the variable X.<br/>
 § assigning a value to an element of a list Text: aList[i] ← X Block: aList ix assigns the value of X to aList[i]. Text: aList[i] ← aList[j] Block: aListaList ij assigns the value of aList[j] to aList[i]. <br/>

--- a/content/unit-5/day-2/parameters.md
+++ b/content/unit-5/day-2/parameters.md
@@ -37,7 +37,7 @@ order: 0
 * [AAP-3.A](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=91) For procedure calls:
     * a. Write statements to call procedures. [3.B](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=23)
     * b. Determine the result or effect of a procedure call. [4.B](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=23)
-* [AAP-3.B](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=94) Explain how the use of procedural abstraction manages complexity in a program. [3.C]()
+* [AAP-3.B](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=94) Explain how the use of procedural abstraction manages complexity in a program. [3.C](https://apcentral.collegeboard.org/pdf/ap-computer-science-principles-course-and-exam-description.pdf?course=ap-computer-science-principles#page=23)
 * AAP-3.C Develop procedural abstractions to manage complexity in a program by writing procedures. 3.B
 
 ### Essential Knowledge 

--- a/content/unit-5/day-20-27/culminating-project.md
+++ b/content/unit-5/day-20-27/culminating-project.md
@@ -12,7 +12,7 @@ order: 0
 * <a href="content\unit-5\day-20-27\planning-your-project.md">Planning Your Unit 5 Project</a> handout
 * [Planning Your Unit 5 Project](https://1drv.ms/w/s!AqsgsTyHBmRBkSQIw0I8KLprv8PB?e=DwO7d3) handout in Word
 * <a href="/unit-5/day-20-27/project-requirements-responses">Project Requirements & Responses</a> handout
-* [Project Requirements & Responses]() handout in Word
+* [Project Requirements & Responses](https://1drv.ms/w/s!AqsgsTyHBmRBkSW52TEONrQkbQfG?e=ZsCc4J) handout in Word
 * <a href="/unit-5/day-20-27/project-rubric">Unit 5 Project Rubric</a>
 * [Unit 5 Project Rubric](https://1drv.ms/w/s!AqsgsTyHBmRBkSW52TEONrQkbQfG?e=ZsCc4J) in Word
 * <a href="/unit-5/day-20-27/gallery-walk">Gallery Walk Feedback Form</a>

--- a/content/unit-7/create-performance-task-prep.md
+++ b/content/unit-7/create-performance-task-prep.md
@@ -27,7 +27,7 @@ Educators will use the following resources in both the Mock Create Performance T
 * [Mac_VideoSubmissionCPT PPT](https://1drv.ms/p/s!AqsgsTyHBmRBkClqTbel_o4O-a2S?e=MScWZB) - Includes directions for screen capturing with Screencastify and Flipgrid.
 * [Chromebook_VideoSubmissionCPT PPT](https://1drv.ms/p/s!AqsgsTyHBmRBkCoO8fWUrOY1-o-F?e=CfFvpV)
 * [iPad_VideoSubmissionCPT PPT](https://1drv.ms/p/s!AqsgsTyHBmRBkCvVPOpkv_xdL8Zy?e=OHQwKQ)
-* [CPT Checklist and Template]() 
+* <a href="/unit-7/cpt-checklist-template">CPT Checklist and Template</a> 
 * [CPT Checklist and Template](https://1drv.ms/w/s!AqsgsTyHBmRBkCz8TGMUtsFsKGNK?e=zMSRnY) in Word - (To be used as a checklist and template for this cell and the ones below this one.)
 
 ### Mock Create Performance Task 3a and 3b
@@ -39,7 +39,7 @@ Educators will use the following resources in both the Mock Create Performance T
 * Mock CPT 3b.iv Writing Response
 * Mock CPT 3b.v Writing Response
 
-* [CPT Checklist and Template](/unit-7/cpt-checklist-template.md)
+* <a href="/unit-7/cpt-checklist-template">CPT Checklist and Template</a>
 * [3a and 3b Discussion PPT](https://1drv.ms/p/s!AqsgsTyHBmRBkC4Cjr9y1iBCVOG6?e=WBfnYl)
 
 ### Mock Create Performance Task 3c and 3d
@@ -51,7 +51,7 @@ Educators will use the following resources in both the Mock Create Performance T
 * Mock CPT 3d.i, 3d.ii, 3d.iii for 1st call Writing Response
 * Mock CPT 3d.i, 3d.ii, 3d.iii for 2nd call Writing Response
 
-* [CPT Checklist and Template]()
+* <a href="/unit-7/cpt-checklist-template">CPT Checklist and Template</a>
 * [3c and 3d Discussion PPT](https://1drv.ms/p/s!AqsgsTyHBmRBkC_keFBX0R4f5yz3?e=sRLMyi)
 
 ### Guide students to create a PDF of their entire program: 

--- a/content/unit-9/day-1/sustainable-development-goals.md
+++ b/content/unit-9/day-1/sustainable-development-goals.md
@@ -8,7 +8,7 @@ order: 0
 
 ### Materials
 
-* [Day 1 PowerPoint deck]()
+* [Day 1 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkQiWIRtlUwBrpqjJ?e=7J7gCd)
 
 #### Websites
 

--- a/content/unit-9/day-2/games-save-world.md
+++ b/content/unit-9/day-2/games-save-world.md
@@ -8,7 +8,7 @@ order: 0
 
 ### Materials
 
-* [Day 2 PowerPoint deck]()
+* [Day 2 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkQlNsP3J4wZ2t_QY?e=DB41U2)
 * Games for Good - example games https://aka.ms/G4Conline<br/>
 NOTE – the Games for Change site (https://www.gamesforchange.org/games) includes games across all platforms, but the link above filters to show just online/web games – students may not have access to play all games
 * COVID Simulation example No Social Distancing - https://makecode.com/_0dW3KLHX4cL9 (for teacher)

--- a/content/unit-9/day-3-6/sdg-project-design-thinking.md
+++ b/content/unit-9/day-3-6/sdg-project-design-thinking.md
@@ -8,9 +8,9 @@ order: 0
 
 ### Materials
 
-* [Days 3-6 PowerPoint deck]()
-* [COVID Simulation example No Social Distancing]() - (for teacher)
-* [COVID Simulation example With Social Distancing]() - (for teacher)
+* [Days 3-6 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkQrOVYA6mwIeeQyP?e=pGjPJA)
+* [COVID Simulation example No Social Distancing](https://makecode.com/_0dW3KLHX4cL9) - (for teacher)
+* [COVID Simulation example With Social Distancing](https://makecode.com/_TecJk15h7i86) - (for teacher)
 * [SDG Project Template](/unit-9/day-3-6/sdg-project-template)
 * [SDG website](https://sdgs.un.org/goals)
 * [Explore SDG partnerships](https://sustainabledevelopment.un.org/partnership/browse/)

--- a/content/unit-9/day-7-8/test-refine-share.md
+++ b/content/unit-9/day-7-8/test-refine-share.md
@@ -8,7 +8,7 @@ order: 0
 
 ### Materials
 
-* [Days 7-8 PowerPoint Deck]()
+* [Days 7-8 PowerPoint Deck](https://1drv.ms/p/s!AqsgsTyHBmRBkQuB5L_Q8-FrzAjH?e=LPWRcM)
 * [SDG Project Distribution Plan](/unit-9/day-7-8/sdg-project-distribution-plan)
 * [MakeCode Forum](https://forum.makecode.com/)
 * [GitHub Pages](https://arcade.makecode.com/github/pages)

--- a/content/unit-9/day-9/reflection.md
+++ b/content/unit-9/day-9/reflection.md
@@ -8,7 +8,7 @@ order: 0
 
 ### Materials
 
-* [Days 9 PowerPoint deck]()
+* [Days 9 PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkQzc1JdTifIfFj5S?e=yIkiTF)
 * [SDG Project Reflection Template](/unit-9/day-9/sdg-project-reflection-template)
 
 ### Instructional Activities and Classroom Assessments 

--- a/content/unit-9/extensions/heartbreak-maps.md
+++ b/content/unit-9/extensions/heartbreak-maps.md
@@ -8,7 +8,7 @@ order: 4
 
 ### Materials
 
-* [Heartbreak Activity PowerPoint deck]()
+* [Heartbreak Activity PowerPoint deck](https://1drv.ms/p/s!AqsgsTyHBmRBkRXcWDUS_Amtr41u?e=aPWWkz)
 * Heartbreak Map Student examples
     * [Joy Kirr's Class](https://www.flickr.com/photos/kirrclass/10156454116/in/album-72157636333106976/)
     * [Aaron Mauer's Class](https://www.flickr.com/photos/coffeechug/sets/72157635407728034/)

--- a/content/unit-9/extensions/microbit-getting-active-picker.md
+++ b/content/unit-9/extensions/microbit-getting-active-picker.md
@@ -13,9 +13,9 @@ The first extension requires the use of Micro:bit boards. While the code activit
 * Full Lesson webpage is here:  
     * [Getting Active Picker](https://microbit.org/lessons/getting-active-picker/)
     * [(lesson download link)](https://microbit.org/downloads/getting-active-5-programming-an-activity-picker.zip)
-* [Getting Active Slides]()
-* [Getting Active Lesson Plan]()
-* [Getting Active Student Handouts]()
+* [Getting Active Slides](https://1drv.ms/p/s!AqsgsTyHBmRBkQ-4a6ToTIjc5zJ2?e=5wb9WZ)
+* [Getting Active Lesson Plan](https://1drv.ms/w/s!AqsgsTyHBmRBkRCDuN6MX9O9ZnoF?e=SyJlRR)
+* [Getting Active Student Handouts](https://1drv.ms/w/s!AqsgsTyHBmRBkREsHoG8Y4Md_Mwn?e=xS0p87)
 
 ### Instructional Activities and Classroom Assessments 
 

--- a/content/unit-9/extensions/minecraft-ee-2.md
+++ b/content/unit-9/extensions/minecraft-ee-2.md
@@ -16,9 +16,9 @@ The second extension requires the use of Minecraft: Education Edition. The app c
 #### Activity 2
 
 * [Hour of Code: A Minecraft Tale of Two Villages Educator Guide](https://1drv.ms/b/s!AqsgsTyHBmRBkRQun04Kopqyo2kH?e=RhoJDN)
-* [Coding Answer Key]() - Answer key for coding exercises in Minecraft Hour of Code 2020 lesson.
-* [Frequently asked questions (FAQ)]() and answers about the 2020 Minecraft Hour of Code. 
-* [Minecraft World Files]()
+* [Coding Answer Key](https://aka.ms/HOCAnswers2020) - Answer key for coding exercises in Minecraft Hour of Code 2020 lesson.
+* [Frequently asked questions (FAQ)](https://aka.ms/HOCFAQ2020) and answers about the 2020 Minecraft Hour of Code. 
+* [Minecraft World Files](https://aka.ms/HOCWorld2020)
 
 ### Instructional Activities and Classroom Assessments
 


### PR DESCRIPTION
Relative links from markdown will get a duplicated path prefix `makecode-csp` prepended. This quirk is handled by using raw anchors instead `<a href="">...</a>`. Using ``<Link>`` will work also but the styles for `<a>` aren't inherited.

- [x] Change relative links from markdown format to `<a>`.
- [x] Check for other missing links too and fill them in.

Re: #43