### PR TITLE
Corrected 'Teacher Guide' link

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -16,7 +16,7 @@ header:
   helpUrl: ""
   links:
     - text: Teacher's Guide
-      link: "/"
+      link: "https://github.com/microsoft/makecode-csp"
       external: false
     - text: PL Trainer Materials
       link: https://aka.ms/MSMakeCodeAPCSPPD

--- a/config/config.yml
+++ b/config/config.yml
@@ -16,7 +16,7 @@ header:
   helpUrl: ""
   links:
     - text: Teacher's Guide
-      link: "https://github.com/microsoft/makecode-csp"
+      link: "https://microsoft.github.io/makecode-csp"
       external: false
     - text: PL Trainer Materials
       link: https://aka.ms/MSMakeCodeAPCSPPD


### PR DESCRIPTION
Root path for 'Teacher Guide' link is not picking up the 'makecode-csp' subpath. Use the full URL for the header link instead.

Fixes #49